### PR TITLE
External resource seam

### DIFF
--- a/.dagger/modules/tests/main.dang
+++ b/.dagger/modules/tests/main.dang
@@ -154,7 +154,7 @@ type Tests {
   }
 
   """
-  Create and compile a pack with ordered External Project Resource roots.
+  Create and compile a pack with ordered External Resource References.
   """
   externalProjectResources: Void @check {
     let source = Dagger
@@ -165,11 +165,11 @@ type Tests {
       .currentModule
       .source
       .directory("fixtures/resources")
-    let resourcePaths = ["/work/resources/first", "/work/resources/second"]
+    let sourceReferences = ["/work/references/first", "/work/references/second"]
     let pack = Dagger.typstPack.create(
       source: source,
-      resourceDir: resources,
-      resourcePaths: resourcePaths,
+      sourceReferenceDir: resources,
+      sourceReferences: sourceReferences,
       externalResources: ["branding/conditional.txt"],
     )
     let output = Dagger.typstPack.inspect(pack)
@@ -185,8 +185,8 @@ type Tests {
       .typstPack
       .compile(
         pack: pack,
-        resourceDir: resources,
-        resourcePaths: resourcePaths,
+        sourceReferenceDir: resources,
+        sourceReferences: sourceReferences,
       )
       .file("output.pdf")
     assert { pdf.size > 0 }

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,18 +5,18 @@ This context describes portable Typst projects and the values that vary between 
 ## Language
 
 **Pack**:
-A portable, reusable Typst project whose compilation contract consists of contained project files and may also include vendored packages, embedded fonts, and declared External Project Resources.
+A portable, reusable Typst project whose compilation contract consists of contained project files and may also include vendored packages, embedded fonts, and declared Resource Slots.
 
 **Pack Manifest**:
 The versioned declarative description carried by a Pack. It describes intended contents and metadata, while agreement between those declarations and contained files is a Pack invariant.
 
-**External Project Resource**:
-A non-source resource addressed through Typst's project root whose path belongs to a pack's compilation contract, but whose bytes are supplied externally instead of being stored in the reusable pack. It may be required or conditional for a particular compilation.
-_Avoid_: Render Asset, asset, external input, customer file, dynamic pack file
+**Resource Slot**:
+A project-root-relative location declared by a Pack for non-source bytes supplied to a compilation rather than stored in the Pack. A slot may remain unfilled when a compilation does not request it.
+_Avoid_: External Project Resource, placeholder, Render Asset, asset, external input, customer file, dynamic pack file
 
-**External Resource Reference**:
-An opaque compilation input identifying a path-addressable source that may supply bytes for one or more External Project Resources. Source references form an ordered fallback chain in which only a missing resource falls through to the next source.
-_Avoid_: Resource Path, resource directory, resource loader
+**Resource Provider**:
+An opaque, path-addressable provider that may supply bytes for one or more Resource Slots. Providers form an ordered fallback chain in which only a missing resource falls through to the next provider.
+_Avoid_: External Resource Provider, External Resource Reference, Source Reference, resource loader
 
 **Document Format**:
 A compilation format that produces one Compilation Output Artifact for a selected or unpaged document. PDF and HTML are Document Formats.
@@ -32,5 +32,5 @@ One file produced by compiling a Pack. It carries its Document Format or Page Fo
 _Avoid_: Output buffer, result file
 
 **Pack Override**:
-A compilation-scoped replacement for a file contained in a pack. Unlike an External Project Resource, it deliberately changes reusable pack content for one compilation.
-_Avoid_: External Project Resource, replacement asset
+A compilation-scoped replacement for a project file contained in a Pack. Unlike a Resource Slot, it deliberately changes reusable project content for one compilation; vendored package files and embedded fonts are not eligible.
+_Avoid_: Resource Slot, replacement asset

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ typst-pack inspect project.typk
 typst-pack compile project.typk output.pdf
 
 # Discover a resource outside the source project, then supply it when compiling:
-typst-pack create invoice/ --resource-path representative-branding/ -o invoice.typk
-typst-pack compile invoice.typk customer.pdf --resource-path customer-branding/
+typst-pack create invoice/ --source-reference representative-branding/ -o invoice.typk
+typst-pack compile invoice.typk customer.pdf --source-reference customer-branding/
 
 # PNG or SVG output, page selection, reproducible builds:
 typst-pack compile project.typk "page-{0p}.png" --ppi 300 --pages 1-3
@@ -105,25 +105,25 @@ An **External Project Resource** is a non-source resource addressed through
 Typst's project root whose path belongs to a pack's compilation contract, but
 whose bytes are supplied externally instead of being stored in the reusable
 pack. This lets one invoice pack use the stable path `assets/logo.png` while a
-different resource root supplies that path for each customer.
+different External Resource Reference supplies that path for each customer.
 
 Discovery does not fall back by default: missing project files are not loaded
-from external resource loaders. Each `--resource-path <DIR>` enables external
-resource discovery and acts as another virtual project root. The source project
-is checked first, then resource roots are checked in command-line order. A file
-loaded from a resource root is recorded under `[project].external-resources`
-and its bytes are omitted from the archive.
+from External Resource References. Each `--source-reference <DIR>` enables
+fallback for creation and registers a filesystem External Resource Reference.
+The source project is checked first, then references are checked in command-line
+order. A file supplied by a reference is recorded under
+`[project].external-resources` and its bytes are omitted from the archive.
 
 Use `--external-resource <PATH>` during creation when a representative file is
 present in the source project but should be omitted, or when a conditional
 resource is not read by the representative discovery compile. Explicitly
 declared paths are recorded even when discovery does not request them.
 
-At compilation time, repeat `--resource-path` to provide the declared paths.
-Packed project files always win, and undeclared missing paths never fall
-through to these roots. External Project Resource loaders cannot supply Typst
-imports/includes or package files. Loading is lazy: a requested resource that
-is unavailable produces Typst's normal file diagnostic.
+At compilation time, repeat `--source-reference` to provide the declared paths.
+Packed project files always win, and undeclared missing paths never consult
+these references. External Resource References cannot supply Typst
+imports/includes or package files. Resolution is lazy: a requested resource
+that is unavailable produces Typst's normal file diagnostic.
 
 Typst 0.15 cannot check whether a path exists, so this version does not provide
 optional-resource detection. Document code that requests an External Project
@@ -196,7 +196,7 @@ let bytes = outcome.pack.to_bytes()?;
 
 // ... ship the bytes somewhere, then compile without a file system:
 let pack = Pack::from_bytes(bytes)?;
-let world = PackWorld::builder(pack).build()?;
+let world = PackWorld::builder(pack).build();
 let output = compile(&world, OutputFormat::Pdf, &CompileOptions::default())?;
 let artifact = output.artifacts.into_iter().next().expect("PDF artifact");
 assert_eq!(artifact.format(), OutputFormat::Pdf);
@@ -221,9 +221,10 @@ let pack = Pack::builder("main.typ")
 let bytes = pack.to_bytes()?;
 ```
 
-External Project Resources can also be declared and supplied in memory. The
-loader uses typst-kit's standard synchronous `FileLoader` interface, so callers
-can adapt memory, object storage, or prefetched application data:
+External Project Resources can also be declared and supplied in memory. An
+External Resource Reference uses typst-kit's standard synchronous `FileLoader`
+interface, so callers can adapt memory, object storage, or prefetched
+application data:
 
 ```rust,ignore
 let pack = Pack::builder("main.typ")
@@ -231,15 +232,36 @@ let pack = Pack::builder("main.typ")
     .external_resource("assets/logo.png")?
     .build()?;
 let world = PackWorld::builder(pack)
-    .external_resource_loader(resource_loader)
-    .build()?;
+    .external_resource_reference(resource_reference)
+    .build();
 ```
 
 For filesystem discovery, configure
 `ProjectResourcePolicy::AllowExternalFallback` and add one or more
-`Packer::external_resource_loader` implementations. Source-project files are
+`Packer::external_resource_reference` implementations. Source-project files are
 checked first; successful fallback loads are inferred as External Project
 Resources.
+
+### Migrating to 0.4
+
+Version 0.4 makes clean naming and invariant-boundary breaks without retaining
+compatibility aliases:
+
+- Replace `PackWorldBuilder::external_resource_loader` and
+  `Packer::external_resource_loader` with `external_resource_reference`.
+- Replace CLI `--resource-path <DIR>` with `--source-reference <DIR>`.
+- `PackWorld::new` and `PackWorldBuilder::build` now return `PackWorld`
+  directly. A successfully constructed Pack already guarantees a contained
+  entrypoint and valid contained fonts.
+- Pack Manifest fields and `PackFont` fields are read-only. Use accessors such
+  as `manifest.project()`, `project.entrypoint()`, `font.manifest()`, and
+  `font.data()`.
+- Shared Pack consistency failures are available as `PackInvariantError`,
+  wrapped by `PackBuildError::Invariant` or `PackReadError::Invariant`.
+
+The Pack format remains version 1. External Project Resource declarations are
+unchanged, and External Resource References remain compilation inputs rather
+than serialized Pack content.
 
 ### Feature flags
 

--- a/dagger.dang
+++ b/dagger.dang
@@ -92,13 +92,13 @@ type TypstPack {
     """
     include: [String!]! = [],
     """
-    Optional External Project Resource directory mounted at /work/resources.
+    Optional filesystem External Resource Reference directory mounted at /work/references.
     """
-    resourceDir: Directory,
+    sourceReferenceDir: Directory,
     """
-    External Project Resource roots. Relative paths resolve from /work/src; absolute paths can reference other mounts.
+    Filesystem External Resource References. Relative paths resolve from /work/src; absolute paths can reference other mounts.
     """
-    resourcePaths: [String!]! = [],
+    sourceReferences: [String!]! = [],
     """
     Root-relative paths to declare as External Project Resources.
     """
@@ -152,7 +152,7 @@ type TypstPack {
     if (embedFonts) { args += ["--embed-fonts"] }
     if (includeTypstEmbeddedFonts) { args += ["--include-typst-embedded-fonts"] }
     include.each { path => args += ["--include", path] }
-    resourcePaths.each { path => args += ["--resource-path", path] }
+    sourceReferences.each { reference => args += ["--source-reference", reference] }
     externalResources.each { path => args += ["--external-resource", path] }
     inputs.each { input => args += ["--input", input] }
     fontPaths.each { path => args += ["--font-path", path] }
@@ -176,8 +176,8 @@ type TypstPack {
     if (fontDir != null) {
       container = container.withMountedDirectory("/work/fonts", fontDir)
     }
-    if (resourceDir != null) {
-      container = container.withMountedDirectory("/work/resources", resourceDir)
+    if (sourceReferenceDir != null) {
+      container = container.withMountedDirectory("/work/references", sourceReferenceDir)
     }
     if (packageDir != null) {
       container = container.withMountedDirectory("/work/packages", packageDir)
@@ -271,13 +271,13 @@ type TypstPack {
     """
     inputs: [String!]! = [],
     """
-    Optional External Project Resource directory mounted at /work/resources.
+    Optional filesystem External Resource Reference directory mounted at /work/references.
     """
-    resourceDir: Directory,
+    sourceReferenceDir: Directory,
     """
-    External Project Resource roots. Relative paths resolve from /work/src; absolute paths can reference other mounts.
+    Filesystem External Resource References. Relative paths resolve from /work/src; absolute paths can reference other mounts.
     """
-    resourcePaths: [String!]! = [],
+    sourceReferences: [String!]! = [],
     """
     Optional font directory mounted at /work/fonts and added to the font search path.
     """
@@ -333,7 +333,7 @@ type TypstPack {
       args += ["--ppi", ppi]
     }
     inputs.each { input => args += ["--input", input] }
-    resourcePaths.each { path => args += ["--resource-path", path] }
+    sourceReferences.each { reference => args += ["--source-reference", reference] }
     fontPaths.each { path => args += ["--font-path", path] }
     if (ignoreEmbeddedFonts) { args += ["--ignore-embedded-fonts"] }
     pdfStandards.each { standard => args += ["--pdf-standard", standard] }
@@ -350,8 +350,8 @@ type TypstPack {
     if (fontDir != null) {
       container = container.withMountedDirectory("/work/fonts", fontDir)
     }
-    if (resourceDir != null) {
-      container = container.withMountedDirectory("/work/resources", resourceDir)
+    if (sourceReferenceDir != null) {
+      container = container.withMountedDirectory("/work/references", sourceReferenceDir)
     }
     if (packageDir != null) {
       container = container.withMountedDirectory("/work/packages", packageDir)

--- a/docs/adr/0002-make-pack-owner-of-whole-pack-invariants.md
+++ b/docs/adr/0002-make-pack-owner-of-whole-pack-invariants.md
@@ -1,0 +1,62 @@
+# ADR-0002: Make Pack the Owner of Whole-Pack Invariants
+
+## Status
+
+Accepted
+
+## Context
+
+Pack Manifest parsing, Zip reconstruction, in-memory building, filesystem
+packing, and Pack-backed compilation previously enforced overlapping subsets of
+Pack validity. A successfully created Pack could still contain an invalid font
+or require downstream entrypoint validation. Canonical path and declaration
+conflict behavior also differed by construction adapter.
+
+The Pack Manifest is still a useful separate module: it owns the versioned TOML
+schema, defaults, unknown-field policy, package-spec syntax, and deterministic
+serialization. It cannot establish agreement with bytes that are not present in
+the manifest.
+
+## Decision
+
+The private `Pack::construct` interface is the authoritative whole-Pack
+construction seam. The in-memory builder and TOML/Zip reader are its two
+adapters. Filesystem packing delegates to the in-memory builder.
+
+The Pack module owns:
+
+- canonical, portable paths and coherent project and package file trees;
+- entrypoint presence;
+- disjoint packed-file and External Project Resource roles;
+- agreement between vendored/external package declarations and package bytes;
+- font path, byte, face-index, and declaration consistency;
+- immutable canonical Pack state; and
+- rejection of ambiguous archive identities before reconstruction.
+
+The Pack Manifest module owns only versioned declarative syntax. Its public
+records are read-only and expose accessors. Generic deserialization and
+`PackManifest::from_toml` use the same version dispatch and manifest-local
+validation.
+
+`PackBuildError` and `PackReadError` wrap the same `PackInvariantError` for
+shared invariant failures. Adapter-specific Zip, I/O, encoding, and ingestion
+failures remain specific to archive reading.
+
+A constructed Pack retains parsed fonts and a canonical contained entrypoint.
+Consequently, `PackWorldBuilder::build` is infallible and does not revalidate
+Pack content.
+
+## Consequences
+
+- Every Pack instance is canonical, immutable, writable, and usable by a
+  Pack-backed World.
+- Writing performs no second invariant pass.
+- Archive compatibility and Pack format version 1 remain unchanged.
+- Safe unknown top-level archive entries remain ignorable, while unsafe or
+  ambiguous entries are rejected before role interpretation.
+- Deleting the private construction seam would redistribute canonicalization
+  and declaration/content agreement into both construction adapters.
+
+Pack Override remains a separate future concept: it is a compilation-scoped
+replacement for contained Pack content, not Pack mutation and not an External
+Project Resource.

--- a/docs/adr/0003-centralize-external-resource-reference-semantics.md
+++ b/docs/adr/0003-centralize-external-resource-reference-semantics.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Superseded by ADR-0004
 
 ## Context
 

--- a/docs/adr/0003-centralize-external-resource-reference-semantics.md
+++ b/docs/adr/0003-centralize-external-resource-reference-semantics.md
@@ -1,0 +1,69 @@
+# ADR-0003: Centralize External Resource Reference Semantics
+
+## Status
+
+Accepted
+
+## Context
+
+Compilation and discovery had separate implementations of External Resource
+Reference behavior. A small shared fallback loop preserved registration order,
+but authority, declaration and policy gating, source/package exclusion,
+canonical missing identity, and discovery provenance remained distributed.
+Changes could therefore weaken one adapter without changing the other.
+
+Pack and Pack Manifest structural rules are a different concern. They establish
+which External Project Resources are declared and ensure contained data does not
+conflict with those declarations.
+
+## Decision
+
+The private `external_resource` module owns runtime and discovery semantics. It
+exposes two crate-private configured contexts:
+
+- `Compilation`, used by the Pack-backed `FileLoader` adapter; and
+- `Discovery`, used by the source-project `FileLoader` adapter.
+
+Both contexts consume ordered opaque `FileLoader` adapters as External Resource
+References. No public trait or public resolution module is introduced.
+
+The shared implementation owns these invariants:
+
+- only project-root raw-file requests are eligible;
+- authoritative Pack or source-project content is consulted first;
+- compilation fallback requires an accepted Pack declaration;
+- discovery fallback requires explicit policy enablement;
+- Typst source and package requests never consult a reference;
+- references are lazy and tried in registration order;
+- only `FileError::NotFound` advances the fallback chain;
+- the first success or any non-missing error stops resolution;
+- all-missing resolution reports the canonical requested project path; and
+- non-missing adapter errors are propagated unchanged.
+
+Discovery provenance starts with explicit declarations. Inferred provenance is
+added only after successful fallback, is stored in deterministic set order, and
+is updated under synchronization. No provenance lock is held while invoking an
+External Resource Reference. Source and raw-file stores remain isolated while
+sharing the authoritative primary cache.
+
+The public Rust registration method is
+`external_resource_reference`. The CLI accepts repeated `--source-reference`
+options. The former loader-oriented Rust names and `--resource-path` option are
+removed without aliases as part of the 0.4 break.
+
+## Consequences
+
+- Compilation and discovery retain distinct Typst adapters while sharing one
+  deep policy implementation.
+- Pack and Pack Manifest retain structural declaration ownership.
+- The module stays usable without filesystem support; filesystem references are
+  CLI adapters, not dependencies of the core implementation.
+- External Resource References are compilation inputs and are not serialized.
+- Compilation Output Artifact behavior established by ADR-0001 is unchanged.
+- Deleting this module would redistribute authority, gating, ordering, error,
+  path-identity, source/package exclusion, and provenance rules across both
+  adapters.
+
+Pack Override remains conceptually separate. It deliberately replaces a file
+contained in a Pack for one compilation; an External Resource Reference may
+only supply a declared External Project Resource.

--- a/docs/adr/0004-model-resource-slots-and-providers.md
+++ b/docs/adr/0004-model-resource-slots-and-providers.md
@@ -1,0 +1,102 @@
+# ADR-0004: Model Resource Slots and Resource Providers
+
+## Status
+
+Accepted
+
+## Context
+
+The terms External Project Resource and External Resource Reference exposed an
+abstract implementation model without explaining the user workflow. In
+particular, `--source-reference` suggested Typst source lookup even though the
+mechanism deliberately rejects source requests. The underlying Pack contract is
+simpler: it declares an exact project location whose non-source bytes are left
+for a compilation to supply.
+
+This decision supersedes ADR-0003. Its centralized resolution seam and most of
+its authority and fallback rules remain, but its public terminology and
+discovery policy do not.
+
+## Decision
+
+A **Resource Slot** is an exact, normalized, project-root-relative location
+declared by a Pack for non-source bytes supplied to a compilation rather than
+stored in the Pack. A slot may remain unfilled when a compilation does not
+request it. Slot declarations carry no required or optional status; an actual
+request determines whether bytes are required for that compilation.
+
+A **Resource Provider** is an opaque, path-addressable compilation input that
+may supply bytes for one or more Resource Slots. Providers form one ordered
+fallback chain. Only a missing resource advances to the next provider; success
+or any other error terminates lookup. Providers cannot supply Typst source,
+package files, undeclared project paths, or replacements for contained Pack
+files. The source restriction follows the Typst request kind rather than the
+path extension.
+
+The filesystem CLI names the concrete value it accepts. Repeated
+`--resource-path <DIR>` options add project-shaped resource roots in command-line
+order, so slot `branding/logo.svg` is looked up as
+`<DIR>/branding/logo.svg`. The explicit declaration vocabulary is
+`--resource-slot <PATH>`, `[project].resource-slots`, and `resource_slot` in
+APIs. Generic APIs accept Resource Providers rather than source references.
+
+Pack creation remains strict and compile-driven. It does not gain partial,
+dummy, or non-discovery modes:
+
+- a same-path source-project file is the first representative value for an
+  explicitly declared slot, but its bytes are omitted from the Pack;
+- Resource Providers are consulted after the source project;
+- registering a provider enables missing non-source requests that it satisfies
+  to be inferred as Resource Slots;
+- explicit declarations cover slots not exercised by representative discovery
+  and present project files that must be omitted;
+- an unrequested slot needs no representative value; and
+- a requested slot that no provider supplies fails creation with a diagnostic
+  explaining how to add a representative project file or resource path.
+
+Representative bytes must be valid for the document and sufficiently
+representative of its dependency behavior. Arbitrary placeholders cannot be
+synthesized safely because images, structured data, and raw files may affect
+layout, control flow, and further dependency discovery.
+
+Resource Providers only fill Resource Slots. A compilation-scoped replacement
+for a contained project file remains a separate future **Pack Override**
+concept; vendored package files and embedded fonts are not override targets.
+
+## Considered Options
+
+- **External Project Resource** was technically neutral but did not identify
+  what was external or explain that the Pack carries a path without bytes.
+- **Late-bound**, **deferred**, and **compile-time resource** emphasized timing
+  without distinguishing slots from ordinary project resources.
+- **Runtime resource**, **include path**, **linked resource**, **mount**, and
+  **overlay** implied unsupported execution, source, reference, or replacement
+  semantics.
+- **File-valued parameter** explained variation but conflicted with Typst's
+  `--input` vocabulary and suggested eager argument binding.
+- **Externalized project file** explained storage but implied prior bytes and
+  understated the path's role as a compilation variation point.
+- Partial discovery and generated dummy values were rejected because they can
+  silently omit dependencies. Non-discovery creation was rejected because it
+  gives up successful representative compilation and automatic package and font
+  discovery.
+
+## Consequences
+
+- Resource Slot declarations and Pack files remain disjoint Pack roles.
+- A Pack with Resource Slots is portable but not self-contained; reproducing a
+  compilation also requires equivalent provider contents and ordering.
+- Availability validation is demand-driven. Structural slot validation remains
+  eager, but unrequested slots are neither resolved nor warned about.
+- Extraction does not materialize empty placeholder files for Resource Slots;
+  it lists the omitted slot paths instead.
+- The filesystem CLI aligns with Typst's `--font-path` and `--package-path`
+  vocabulary without leaking the generic provider abstraction.
+- The manifest, CLI, Rust API, Dagger API, documentation, diagnostics, and tests
+  require a coordinated breaking terminology migration.
+- Pack Manifest format version 1 is still unstable. Its schema changes in place
+  to use `resource-slots` and `packages.unvendored`; Packs written with the old
+  version-1 field names need not remain readable, and no field aliases are kept.
+- The private centralized resolver retained from ADR-0003 continues to own Pack
+  authority, slot eligibility, source/package exclusion, provider ordering,
+  missing-only fallback, canonical missing identity, and discovery provenance.

--- a/docs/adr/0005-align-cli-with-embedded-typst.md
+++ b/docs/adr/0005-align-cli-with-embedded-typst.md
@@ -1,0 +1,129 @@
+# ADR-0005: Align the CLI with Embedded Typst
+
+## Status
+
+Accepted
+
+## Context
+
+`typst-pack compile` invokes the Typst compiler but had accumulated different
+spellings, parsers, environment variables, help text, and exporter behavior from
+`typst compile`. Some differences express the Pack compilation contract, while
+others are accidental and make existing Typst knowledge unreliable.
+
+## Decision
+
+The CLI parity baseline is the exact Typst engine version embedded by
+typst-pack. Shared flags track that version's spelling, values, parsing,
+environment variables, semantics, and help text. A Typst engine upgrade includes
+an explicit CLI parity review. `typst-pack --version` reports both versions.
+
+The command shapes are:
+
+```text
+typst-pack create [OPTIONS] <INPUT> [OUTPUT]
+typst-pack compile [OPTIONS] <PACK> [OUTPUT]
+```
+
+`create` requires an input Typst file and removes directory-as-input and
+`--entrypoint`. Its `--root` behavior, `TYPST_ROOT` environment support, and
+default root match Typst. The default Pack output replaces the input extension
+with `.typk`; `OUTPUT=-` writes the Pack to stdout. Source input from stdin is
+not supported because a Pack must retain a stable project-relative entrypoint.
+The Pack Manifest continues to call that persisted role `entrypoint`.
+
+`compile` retains `<PACK>` rather than calling it `<INPUT>`. `PACK=-` reads a
+Pack from stdin and then requires an explicit output. There is no compile-time
+`--root`: the Pack owns the virtual project tree, and Resource Providers can
+fill only declared Resource Slots. `OUTPUT=-` writes stdout when exactly one
+output file is emitted and is rejected for multi-file output.
+
+Shared Typst behavior includes:
+
+- `--input` parsing, including whitespace trimming and empty-key rejection;
+- case-insensitive output-format inference and Typst's supported extensions;
+- Page Format templates, total-page semantics, aliases, and page-range grammar;
+- `--pretty`, `--pages`, `--ppi`, `--pdf-standard`, and `--no-pdf-tags`;
+- `--creation-timestamp` and `SOURCE_DATE_EPOCH` validation and timestamp
+  behavior;
+- `--font-path`, embedded/system font controls, path-list parsing, and Typst's
+  font environment variables;
+- `--package-path`, `--package-cache-path`, and Typst's package environment
+  variables;
+- `--features` for every applicable embedded feature, including `html` and
+  `a11y-extras`;
+- `-j/--jobs`, `--diagnostic-format`, `--timings`, and `--open [VIEWER]`;
+- `--deps` and `--deps-format`; and
+- global `--color` and `--cert`/`TYPST_CERT` controls.
+
+`compile` exposes the visible `c` alias. Typst source diagnostics are not
+followed by an extra generic `error: compilation failed` line.
+
+Page Format output requires an indexable page-number template when more than
+one page is emitted; typst-pack does not invent a default template. Document
+Format output paths are literal. Valid multi-output paths may still be
+preflighted before writing to avoid partial output or duplicate destinations.
+
+Dependency output has Pack-aware host-rebuild semantics. It reports the Pack
+path once for contained content, plus actual filesystem-backed Resource Slot
+and unvendored package files read during compilation. It does not invent host
+paths for archive members or opaque providers.
+
+Pack creation performs one strict discovery compile for each selected
+`--target <paged|html>` and unions their dependencies. The option is repeatable
+and comma-delimited and defaults to `paged`. `create` reuses every
+target-independent compilation control that affects discovery, including
+inputs, timestamps, features, jobs, diagnostics, timings, fonts, packages,
+certificates, and color. Export-, page-, and PDF-specific options remain
+compile-only.
+
+Pack-specific additions remain explicit:
+
+- `--resource-path <DIR>` configures ordered filesystem Resource Providers as
+  established by ADR-0004;
+- `--offline` prevents package downloads;
+- `create --resource-slot <PATH>` declares Resource Slots;
+- `create --no-vendor-packages` controls package storage; and
+- creation retains project inclusion, font embedding, and Pack metadata
+  controls.
+
+Routine CLI help uses Typst's plain output-file, output-format, and page-number
+wording. Formal terms such as Compilation Output Artifact, Document Format,
+Page Format, and Source Page Number remain available to library and domain
+documentation where their distinctions matter.
+
+Help is grouped by user task rather than copied as Typst's flat list.
+`compile` uses Compilation, Output, PDF, Resource Slots, Fonts, Packages, and
+Diagnostics & Automation sections. `create` uses Project, Discovery, Pack
+Contents, Resource Slots, Fonts, Packages, Metadata, and Diagnostics &
+Automation sections.
+
+The Dagger API follows semantic rather than transport parity. It exposes
+compiler behavior that has a meaningful typed representation, but not terminal
+viewing, stdout, color, or arbitrary local output paths. Its creation inputs use
+`project`, `input`, and `sysInputs`; ordered `resourceDirs` are mounted and
+registered automatically, and explicit declarations are `resourceSlots`.
+
+## Intentional Differences
+
+- Typst Bundle output and its feature are not supported.
+- A `watch` command is deferred because correctly watching Packs, selected
+  Resource Provider files, packages, and font paths requires a separate
+  dependency/provenance design.
+- `create` does not accept source input from stdin.
+- `compile` has no `--root` and consumes a Pack rather than a Typst source file.
+- Pack-contained fonts and vendored packages remain authoritative layers ahead
+  of host configuration.
+- The hidden deprecated `--make-deps` compatibility option is not adopted.
+
+## Consequences
+
+- Existing Typst knowledge applies by default; each divergence is a Pack
+  contract decision rather than accidental drift.
+- Shared argument definitions and parsers should be reused by `create` and
+  `compile`, while help headings remain task-specific.
+- CLI tests need to cover upstream-compatible parsing, environment variables,
+  help text, stdout conflicts, output templates, and every intentional
+  difference.
+- New Typst compile options are not adopted blindly: each engine upgrade checks
+  whether the option applies to Pack compilation and records exclusions.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,7 @@ use crate::extract::{ExtractOptions, extract};
 use crate::manifest::PackMetadata;
 use crate::pack::{FILE_EXTENSION, Pack};
 use crate::packer::{DiscoveryWorld, Packer, PackerError, ProjectResourcePolicy};
-use crate::world::{PackWorld, PackWorldError, SystemPackageLoader};
+use crate::world::{PackWorld, SystemPackageLoader};
 
 /// Pack, inspect, extract, and compile portable Typst project packs.
 #[derive(Debug, Parser)]
@@ -83,9 +83,9 @@ struct CreateArgs {
     #[arg(long = "include", value_name = "PATH")]
     include: Vec<PathBuf>,
 
-    /// Directories that act as roots for External Project Resources during discovery.
-    #[arg(long = "resource-path", value_name = "DIR")]
-    resource_paths: Vec<PathBuf>,
+    /// Filesystem External Resource References used during discovery.
+    #[arg(long = "source-reference", value_name = "DIR")]
+    source_references: Vec<PathBuf>,
 
     /// Root-relative resource paths to declare as external even if discovery does not load them.
     #[arg(long = "external-resource", value_name = "PATH")]
@@ -204,9 +204,9 @@ struct CompileArgs {
     #[arg(long = "input", value_name = "KEY=VALUE")]
     inputs: Vec<String>,
 
-    /// Directories that act as roots for External Project Resources.
-    #[arg(long = "resource-path", value_name = "DIR")]
-    resource_paths: Vec<PathBuf>,
+    /// Filesystem External Resource References used during compilation.
+    #[arg(long = "source-reference", value_name = "DIR")]
+    source_references: Vec<PathBuf>,
 
     /// Additional directories to search for fonts.
     #[arg(long = "font-path", value_name = "DIR")]
@@ -313,11 +313,11 @@ fn create(args: CreateArgs) -> Result<(), String> {
     for path in &args.include {
         packer = packer.include(path);
     }
-    if !args.resource_paths.is_empty() {
+    if !args.source_references.is_empty() {
         packer = packer.project_resource_policy(ProjectResourcePolicy::AllowExternalFallback);
     }
-    for path in &args.resource_paths {
-        packer = packer.external_resource_loader(ProjectResourceRoot::new(path.clone()));
+    for path in &args.source_references {
+        packer = packer.external_resource_reference(FilesystemReference::new(path.clone()));
     }
     for path in args.external_resources {
         packer = packer.external_resource(path);
@@ -332,11 +332,17 @@ fn create(args: CreateArgs) -> Result<(), String> {
         packer = packer.package_cache_path(path);
     }
     if args.name.is_some() || args.description.is_some() || !args.authors.is_empty() {
-        packer = packer.metadata(PackMetadata {
-            name: args.name,
-            description: args.description,
-            authors: args.authors,
-        });
+        let mut metadata = PackMetadata::new();
+        if let Some(name) = args.name {
+            metadata = metadata.with_name(name);
+        }
+        if let Some(description) = args.description {
+            metadata = metadata.with_description(description);
+        }
+        for author in args.authors {
+            metadata = metadata.with_author(author);
+        }
+        packer = packer.metadata(metadata);
     }
 
     let outcome = match packer.pack() {
@@ -398,17 +404,17 @@ fn inspect(args: InspectArgs) -> Result<(), String> {
     let manifest = pack.manifest();
 
     println!("pack: {}", args.pack.display());
-    println!("format version: {}", manifest.format_version);
+    println!("format version: {}", manifest.format_version());
     println!("entrypoint: {}", pack.entrypoint());
-    if let Some(metadata) = &manifest.metadata {
-        if let Some(name) = &metadata.name {
+    if let Some(metadata) = manifest.metadata() {
+        if let Some(name) = metadata.name() {
             println!("name: {name}");
         }
-        if let Some(description) = &metadata.description {
+        if let Some(description) = metadata.description() {
             println!("description: {description}");
         }
-        if !metadata.authors.is_empty() {
-            println!("authors: {}", metadata.authors.join(", "));
+        if !metadata.authors().is_empty() {
+            println!("authors: {}", metadata.authors().join(", "));
         }
     }
 
@@ -417,9 +423,9 @@ fn inspect(args: InspectArgs) -> Result<(), String> {
         println!("  {path} ({})", human_size(data.len()));
     }
 
-    if !manifest.project.external_resources.is_empty() {
+    if manifest.project().external_resources().next().is_some() {
         println!("\nexternal project resources:");
-        for path in &manifest.project.external_resources {
+        for path in manifest.project().external_resources() {
             println!("  {path}");
         }
     }
@@ -434,9 +440,9 @@ fn inspect(args: InspectArgs) -> Result<(), String> {
             println!("  {spec} ({count} files, {})", human_size(size));
         }
     }
-    if !manifest.packages.unvendored.is_empty() {
+    if !manifest.packages().unvendored().is_empty() {
         println!("\nunvendored packages:");
-        for spec in &manifest.packages.unvendored {
+        for spec in manifest.packages().unvendored() {
             println!("  {spec}");
         }
     }
@@ -446,12 +452,12 @@ fn inspect(args: InspectArgs) -> Result<(), String> {
         for font in pack.fonts() {
             println!(
                 "  {} ({}){}",
-                font.entry.path,
-                human_size(font.data.len()),
-                if font.entry.families.is_empty() {
+                font.manifest().path(),
+                human_size(font.data().len()),
+                if font.manifest().families().is_empty() {
                     String::new()
                 } else {
-                    format!(" - {}", font.entry.families.join(", "))
+                    format!(" - {}", font.manifest().families().join(", "))
                 }
             );
         }
@@ -535,8 +541,8 @@ fn compile_command(args: CompileArgs) -> Result<(), String> {
     if args.features.iter().any(|feature| feature == "html") {
         builder = builder.feature(typst::Feature::Html);
     }
-    for path in &args.resource_paths {
-        builder = builder.external_resource_loader(ProjectResourceRoot::new(path.clone()));
+    for path in &args.source_references {
+        builder = builder.external_resource_reference(FilesystemReference::new(path.clone()));
     }
     builder = match creation_timestamp {
         Some(datetime) => builder.fixed_date(datetime),
@@ -549,9 +555,7 @@ fn compile_command(args: CompileArgs) -> Result<(), String> {
         builder = builder.extra_fonts(typst_kit::fonts::system());
     }
 
-    let world = builder
-        .build()
-        .map_err(|err: PackWorldError| err.to_string())?;
+    let world = builder.build();
 
     let page_selection = match &args.pages {
         Some(text) => parse_page_selection(text)?,
@@ -745,15 +749,15 @@ fn parse_inputs(pairs: &[String]) -> Result<Dict, String> {
     Ok(dict)
 }
 
-struct ProjectResourceRoot(FsRoot);
+struct FilesystemReference(FsRoot);
 
-impl ProjectResourceRoot {
+impl FilesystemReference {
     fn new(root: PathBuf) -> Self {
         Self(FsRoot::new(root))
     }
 }
 
-impl FileLoader for ProjectResourceRoot {
+impl FileLoader for FilesystemReference {
     fn load(&self, id: FileId) -> FileResult<Bytes> {
         match id.root() {
             VirtualRoot::Project => self.0.load(id.vpath()),

--- a/src/external_resource.rs
+++ b/src/external_resource.rs
@@ -1,0 +1,151 @@
+//! Runtime interpretation of External Resource References.
+
+use std::path::PathBuf;
+
+#[cfg(feature = "fs")]
+use std::collections::BTreeSet;
+#[cfg(feature = "fs")]
+use std::sync::Mutex;
+
+use typst::diag::{FileError, FileResult};
+use typst::foundations::Bytes;
+use typst::syntax::{FileId, VirtualRoot};
+use typst_kit::files::FileLoader;
+
+use crate::Pack;
+
+pub(crate) type Reference = Box<dyn FileLoader + Send + Sync>;
+
+struct ReferenceChain(Vec<Reference>);
+
+impl ReferenceChain {
+    fn resolve(&self, id: FileId) -> FileResult<Bytes> {
+        for reference in &self.0 {
+            match reference.load(id) {
+                Err(FileError::NotFound(_)) => {}
+                result => return result,
+            }
+        }
+        missing(id)
+    }
+}
+
+pub(crate) struct Compilation {
+    references: ReferenceChain,
+}
+
+impl Compilation {
+    pub(crate) fn new(references: Vec<Reference>) -> Self {
+        Self {
+            references: ReferenceChain(references),
+        }
+    }
+
+    pub(crate) fn file(&self, pack: &Pack, id: FileId) -> Option<FileResult<Bytes>> {
+        if !matches!(id.root(), VirtualRoot::Project) {
+            return None;
+        }
+        let path = id.vpath().get_without_slash();
+        Some(match pack.file(path) {
+            Some(data) => Ok(data.clone()),
+            None if pack.is_external_resource(path) => self.references.resolve(id),
+            None => missing(id),
+        })
+    }
+
+    pub(crate) fn source<T>(
+        &self,
+        pack: &Pack,
+        id: FileId,
+        authoritative: impl FnOnce() -> FileResult<T>,
+    ) -> FileResult<T> {
+        if matches!(id.root(), VirtualRoot::Project)
+            && pack.file(id.vpath().get_without_slash()).is_none()
+        {
+            return missing(id);
+        }
+        authoritative()
+    }
+}
+
+#[cfg(feature = "fs")]
+pub(crate) struct Discovery {
+    references: ReferenceChain,
+    allow_fallback: bool,
+    explicit: BTreeSet<String>,
+    provenance: Mutex<BTreeSet<String>>,
+}
+
+#[cfg(feature = "fs")]
+impl Discovery {
+    pub(crate) fn new(
+        references: Vec<Reference>,
+        allow_fallback: bool,
+        explicit: BTreeSet<String>,
+    ) -> Self {
+        Self {
+            references: ReferenceChain(references),
+            allow_fallback,
+            provenance: Mutex::new(explicit.clone()),
+            explicit,
+        }
+    }
+
+    pub(crate) fn file(
+        &self,
+        id: FileId,
+        authoritative: impl FnOnce() -> FileResult<Bytes>,
+    ) -> FileResult<Bytes> {
+        let result = authoritative();
+        if !matches!(id.root(), VirtualRoot::Project) {
+            return result;
+        }
+        match result {
+            Ok(data) => Ok(data),
+            Err(FileError::NotFound(_)) if self.allow_fallback => {
+                let data = self.references.resolve(id)?;
+                self.provenance
+                    .lock()
+                    .expect("External Project Resource provenance lock poisoned")
+                    .insert(id.vpath().get_without_slash().to_owned());
+                Ok(data)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    pub(crate) fn source<T>(
+        &self,
+        id: FileId,
+        authoritative: impl FnOnce() -> FileResult<T>,
+    ) -> FileResult<T> {
+        if matches!(id.root(), VirtualRoot::Project)
+            && self.explicit.contains(id.vpath().get_without_slash())
+        {
+            return missing(id);
+        }
+        authoritative()
+    }
+
+    pub(crate) fn is_external(&self, id: FileId) -> bool {
+        self.provenance
+            .lock()
+            .expect("External Project Resource provenance lock poisoned")
+            .contains(id.vpath().get_without_slash())
+    }
+
+    pub(crate) fn external_resources(&self) -> Vec<String> {
+        self.provenance
+            .lock()
+            .expect("External Project Resource provenance lock poisoned")
+            .iter()
+            .cloned()
+            .collect()
+    }
+}
+
+fn missing<T>(id: FileId) -> FileResult<T> {
+    Err(FileError::NotFound(PathBuf::from(
+        id.vpath().get_without_slash(),
+    )))
+}

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -69,11 +69,11 @@ pub fn extract(
 
     if options.fonts {
         for font in pack.fonts() {
-            let path = Path::new(&font.entry.path);
+            let path = Path::new(font.manifest().path());
             if report.written.iter().any(|written| written == path) {
                 continue;
             }
-            write_file(dir, path, &font.data, options, &mut report)?;
+            write_file(dir, path, font.data(), options, &mut report)?;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 mod compile;
+mod external_resource;
 mod extract;
 mod manifest;
 mod pack;
@@ -19,9 +20,10 @@ pub use manifest::{
     PackagesManifest, ProjectManifest,
 };
 pub use pack::{
-    FILE_EXTENSION, Pack, PackBuildError, PackBuilder, PackFont, PackReadError, PackWriteError,
+    FILE_EXTENSION, Pack, PackBuildError, PackBuilder, PackFont, PackInvariantError, PackPathRole,
+    PackReadError, PackWriteError,
 };
-pub use world::{PackWorld, PackWorldBuilder, PackWorldError};
+pub use world::{PackWorld, PackWorldBuilder};
 
 #[cfg(feature = "fs")]
 pub use extract::{ExtractError, ExtractOptions, ExtractReport, extract};

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -64,19 +64,7 @@ impl<'de> Deserialize<'de> for PackManifest {
         D: Deserializer<'de>,
     {
         let value = toml::Value::deserialize(deserializer)?;
-        let version = value
-            .get("format-version")
-            .and_then(toml::Value::as_integer)
-            .ok_or_else(|| serde::de::Error::custom("missing or invalid `format-version`"))?;
-        if version != i64::from(FORMAT_VERSION) {
-            return Err(serde::de::Error::custom(format!(
-                "unsupported pack format version {version}"
-            )));
-        }
-        let wire: Version1Manifest = value.try_into().map_err(serde::de::Error::custom)?;
-        let manifest = Self::try_from(wire).map_err(serde::de::Error::custom)?;
-        manifest.validate().map_err(serde::de::Error::custom)?;
-        Ok(manifest)
+        parse_manifest_value(value).map_err(serde::de::Error::custom)
     }
 }
 
@@ -284,6 +272,8 @@ impl PackMetadata {
 pub enum PackManifestError {
     #[error("failed to parse manifest: {0}")]
     Parse(#[from] toml::de::Error),
+    #[error("missing or invalid `format-version`")]
+    InvalidFormatVersion,
     #[error("unsupported pack format version {0} (this reader supports version {FORMAT_VERSION})")]
     UnsupportedVersion(u32),
     #[error("invalid package spec `{spec}`: {message}")]
@@ -341,20 +331,7 @@ impl PackManifest {
 
     /// Parses and validates a manifest from TOML text.
     pub fn from_toml(text: &str) -> Result<Self, PackManifestError> {
-        #[derive(Deserialize)]
-        #[serde(rename_all = "kebab-case")]
-        struct VersionProbe {
-            format_version: u32,
-        }
-
-        let probe: VersionProbe = toml::from_str(text)?;
-        if probe.format_version != FORMAT_VERSION {
-            return Err(PackManifestError::UnsupportedVersion(probe.format_version));
-        }
-        let wire: Version1Manifest = toml::from_str(text)?;
-        let manifest = Self::try_from(wire)?;
-        manifest.validate()?;
-        Ok(manifest)
+        parse_manifest_value(toml::from_str(text)?)
     }
 
     /// Serializes the manifest to TOML text.
@@ -379,6 +356,21 @@ impl PackManifest {
     pub fn unvendored_packages(&self) -> &[PackageSpec] {
         &self.packages.unvendored
     }
+}
+
+fn parse_manifest_value(value: toml::Value) -> Result<PackManifest, PackManifestError> {
+    let version = value
+        .get("format-version")
+        .and_then(toml::Value::as_integer)
+        .ok_or(PackManifestError::InvalidFormatVersion)?;
+    let version = u32::try_from(version).map_err(|_| PackManifestError::InvalidFormatVersion)?;
+    if version != FORMAT_VERSION {
+        return Err(PackManifestError::UnsupportedVersion(version));
+    }
+    let wire: Version1Manifest = value.try_into()?;
+    let manifest = PackManifest::try_from(wire)?;
+    manifest.validate()?;
+    Ok(manifest)
 }
 
 fn parse_specs(specs: Vec<String>) -> Result<Vec<PackageSpec>, PackManifestError> {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,9 +1,9 @@
 //! The pack manifest stored as `typst-pack.toml` inside the archive.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use typst::syntax::package::PackageSpec;
 
 /// The archive entry name of the manifest.
@@ -37,22 +37,24 @@ struct Version1Manifest {
     format_version: u32,
     project: ProjectManifest,
     #[serde(default)]
-    packages: PackagesManifest,
+    packages: Version1PackagesManifest,
     #[serde(default)]
     fonts: Vec<FontManifest>,
     #[serde(default)]
     metadata: Option<PackMetadata>,
 }
 
-impl From<Version1Manifest> for PackManifest {
-    fn from(manifest: Version1Manifest) -> Self {
-        Self {
+impl TryFrom<Version1Manifest> for PackManifest {
+    type Error = PackManifestError;
+
+    fn try_from(manifest: Version1Manifest) -> Result<Self, Self::Error> {
+        Ok(Self {
             format_version: manifest.format_version,
             project: manifest.project,
-            packages: manifest.packages,
+            packages: manifest.packages.try_into()?,
             fonts: manifest.fonts,
             metadata: manifest.metadata,
-        }
+        })
     }
 }
 
@@ -72,7 +74,7 @@ impl<'de> Deserialize<'de> for PackManifest {
             )));
         }
         let wire: Version1Manifest = value.try_into().map_err(serde::de::Error::custom)?;
-        let manifest = Self::from(wire);
+        let manifest = Self::try_from(wire).map_err(serde::de::Error::custom)?;
         manifest.validate().map_err(serde::de::Error::custom)?;
         Ok(manifest)
     }
@@ -90,17 +92,64 @@ pub struct ProjectManifest {
 }
 
 /// The `[packages]` section.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct PackagesManifest {
     /// Exact specs of packages whose files are stored inside the pack.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    vendored: Vec<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        serialize_with = "serialize_package_specs"
+    )]
+    vendored: Vec<PackageSpec>,
     /// Exact specs of observed dependencies that are *not* stored inside the
     /// pack and must be resolved from a package directory, cache, or registry
     /// when compiling.
-    #[serde(default, rename = "external", skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        rename = "external",
+        skip_serializing_if = "Vec::is_empty",
+        serialize_with = "serialize_package_specs"
+    )]
+    unvendored: Vec<PackageSpec>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct Version1PackagesManifest {
+    #[serde(default)]
+    vendored: Vec<String>,
+    #[serde(default, rename = "external")]
     unvendored: Vec<String>,
+}
+
+impl TryFrom<Version1PackagesManifest> for PackagesManifest {
+    type Error = PackManifestError;
+
+    fn try_from(packages: Version1PackagesManifest) -> Result<Self, Self::Error> {
+        Ok(Self {
+            vendored: parse_specs(packages.vendored)?,
+            unvendored: parse_specs(packages.unvendored)?,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for PackagesManifest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Version1PackagesManifest::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+fn serialize_package_specs<S>(specs: &[PackageSpec], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.collect_seq(specs.iter().map(ToString::to_string))
 }
 
 /// One `[[fonts]]` entry.
@@ -151,12 +200,12 @@ impl ProjectManifest {
 
 impl PackagesManifest {
     /// Exact specifications of packages stored inside the Pack.
-    pub fn vendored(&self) -> &[String] {
+    pub fn vendored(&self) -> &[PackageSpec] {
         &self.vendored
     }
 
     /// Exact specifications of packages resolved outside the Pack.
-    pub fn unvendored(&self) -> &[String] {
+    pub fn unvendored(&self) -> &[PackageSpec] {
         &self.unvendored
     }
 
@@ -245,8 +294,8 @@ impl PackManifest {
     pub(crate) fn new(
         entrypoint: String,
         external_resources: BTreeSet<String>,
-        vendored_packages: Vec<String>,
-        external_packages: Vec<String>,
+        vendored_packages: Vec<PackageSpec>,
+        external_packages: Vec<PackageSpec>,
         fonts: Vec<FontManifest>,
         metadata: Option<PackMetadata>,
     ) -> Self {
@@ -257,8 +306,8 @@ impl PackManifest {
                 external_resources,
             },
             packages: PackagesManifest {
-                vendored: vendored_packages,
-                unvendored: external_packages,
+                vendored: canonical_specs(vendored_packages),
+                unvendored: canonical_specs(external_packages),
             },
             fonts,
             metadata,
@@ -303,7 +352,7 @@ impl PackManifest {
             return Err(PackManifestError::UnsupportedVersion(probe.format_version));
         }
         let wire: Version1Manifest = toml::from_str(text)?;
-        let manifest = Self::from(wire);
+        let manifest = Self::try_from(wire)?;
         manifest.validate()?;
         Ok(manifest)
     }
@@ -318,39 +367,38 @@ impl PackManifest {
         if self.format_version != FORMAT_VERSION {
             return Err(PackManifestError::UnsupportedVersion(self.format_version));
         }
-        for spec in self
-            .packages
-            .vendored
-            .iter()
-            .chain(&self.packages.unvendored)
-        {
-            parse_spec(spec)?;
-        }
         Ok(())
     }
 
-    /// The vendored package specs, parsed.
-    pub fn vendored_packages(&self) -> Result<Vec<PackageSpec>, PackManifestError> {
-        self.packages
-            .vendored
-            .iter()
-            .map(|spec| parse_spec(spec))
-            .collect()
+    /// The vendored package specs.
+    pub fn vendored_packages(&self) -> &[PackageSpec] {
+        &self.packages.vendored
     }
 
-    /// The unvendored package specs, parsed.
-    pub fn unvendored_packages(&self) -> Result<Vec<PackageSpec>, PackManifestError> {
-        self.packages
-            .unvendored
-            .iter()
-            .map(|spec| parse_spec(spec))
-            .collect()
+    /// The unvendored package specs.
+    pub fn unvendored_packages(&self) -> &[PackageSpec] {
+        &self.packages.unvendored
     }
 }
 
-fn parse_spec(spec: &str) -> Result<PackageSpec, PackManifestError> {
-    PackageSpec::from_str(spec).map_err(|err| PackManifestError::InvalidPackageSpec {
-        spec: spec.to_owned(),
-        message: err.to_string(),
-    })
+fn parse_specs(specs: Vec<String>) -> Result<Vec<PackageSpec>, PackManifestError> {
+    specs
+        .into_iter()
+        .map(|spec| {
+            PackageSpec::from_str(&spec).map_err(|err| PackManifestError::InvalidPackageSpec {
+                spec,
+                message: err.to_string(),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(canonical_specs)
+}
+
+fn canonical_specs(specs: Vec<PackageSpec>) -> Vec<PackageSpec> {
+    specs
+        .into_iter()
+        .map(|spec| (spec.to_string(), spec))
+        .collect::<BTreeMap<_, _>>()
+        .into_values()
+        .collect()
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -3,8 +3,7 @@
 use std::collections::BTreeSet;
 use std::str::FromStr;
 
-use serde::{Deserialize, Serialize};
-use typst::syntax::VirtualPath;
+use serde::{Deserialize, Deserializer, Serialize};
 use typst::syntax::package::PackageSpec;
 
 /// The archive entry name of the manifest.
@@ -14,22 +13,69 @@ pub const MANIFEST_PATH: &str = "typst-pack.toml";
 pub const FORMAT_VERSION: u32 = 1;
 
 /// The parsed contents of `typst-pack.toml`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct PackManifest {
     /// The pack format version. Readers must reject versions they don't know.
-    pub format_version: u32,
+    format_version: u32,
     /// The packed Typst project.
-    pub project: ProjectManifest,
+    project: ProjectManifest,
     /// Package dependencies observed while creating the pack.
     #[serde(default, skip_serializing_if = "PackagesManifest::is_empty")]
-    pub packages: PackagesManifest,
+    packages: PackagesManifest,
     /// Fonts embedded in the pack.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub fonts: Vec<FontManifest>,
+    fonts: Vec<FontManifest>,
     /// Optional descriptive metadata about the packed project.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<PackMetadata>,
+    metadata: Option<PackMetadata>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct Version1Manifest {
+    format_version: u32,
+    project: ProjectManifest,
+    #[serde(default)]
+    packages: PackagesManifest,
+    #[serde(default)]
+    fonts: Vec<FontManifest>,
+    #[serde(default)]
+    metadata: Option<PackMetadata>,
+}
+
+impl From<Version1Manifest> for PackManifest {
+    fn from(manifest: Version1Manifest) -> Self {
+        Self {
+            format_version: manifest.format_version,
+            project: manifest.project,
+            packages: manifest.packages,
+            fonts: manifest.fonts,
+            metadata: manifest.metadata,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PackManifest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = toml::Value::deserialize(deserializer)?;
+        let version = value
+            .get("format-version")
+            .and_then(toml::Value::as_integer)
+            .ok_or_else(|| serde::de::Error::custom("missing or invalid `format-version`"))?;
+        if version != i64::from(FORMAT_VERSION) {
+            return Err(serde::de::Error::custom(format!(
+                "unsupported pack format version {version}"
+            )));
+        }
+        let wire: Version1Manifest = value.try_into().map_err(serde::de::Error::custom)?;
+        let manifest = Self::from(wire);
+        manifest.validate().map_err(serde::de::Error::custom)?;
+        Ok(manifest)
+    }
 }
 
 /// The `[project]` section.
@@ -37,10 +83,10 @@ pub struct PackManifest {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ProjectManifest {
     /// The root-relative path of the entrypoint file, e.g. `main.typ`.
-    pub entrypoint: String,
+    entrypoint: String,
     /// Non-source project resources supplied externally at compilation time.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
-    pub external_resources: BTreeSet<String>,
+    external_resources: BTreeSet<String>,
 }
 
 /// The `[packages]` section.
@@ -49,18 +95,12 @@ pub struct ProjectManifest {
 pub struct PackagesManifest {
     /// Exact specs of packages whose files are stored inside the pack.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub vendored: Vec<String>,
+    vendored: Vec<String>,
     /// Exact specs of observed dependencies that are *not* stored inside the
     /// pack and must be resolved from a package directory, cache, or registry
     /// when compiling.
     #[serde(default, rename = "external", skip_serializing_if = "Vec::is_empty")]
-    pub unvendored: Vec<String>,
-}
-
-impl PackagesManifest {
-    fn is_empty(&self) -> bool {
-        self.vendored.is_empty() && self.unvendored.is_empty()
-    }
+    unvendored: Vec<String>,
 }
 
 /// One `[[fonts]]` entry.
@@ -68,13 +108,13 @@ impl PackagesManifest {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct FontManifest {
     /// The archive entry holding the font data, e.g. `fonts/dejavu-sans.ttf`.
-    pub path: String,
+    path: String,
     /// The face index inside the font file (non-zero for collections).
     #[serde(default, skip_serializing_if = "is_zero")]
-    pub index: u32,
+    index: u32,
     /// Family names provided by this face, informational only.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub families: Vec<String>,
+    families: Vec<String>,
 }
 
 fn is_zero(index: &u32) -> bool {
@@ -86,11 +126,108 @@ fn is_zero(index: &u32) -> bool {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct PackMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+    description: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub authors: Vec<String>,
+    authors: Vec<String>,
+}
+
+impl ProjectManifest {
+    /// The root-relative entrypoint path.
+    pub fn entrypoint(&self) -> &str {
+        &self.entrypoint
+    }
+
+    /// The declared External Project Resource paths in deterministic order.
+    pub fn external_resources(&self) -> impl Iterator<Item = &str> {
+        self.external_resources.iter().map(String::as_str)
+    }
+
+    pub(crate) fn contains_external_resource(&self, path: &str) -> bool {
+        self.external_resources.contains(path)
+    }
+}
+
+impl PackagesManifest {
+    /// Exact specifications of packages stored inside the Pack.
+    pub fn vendored(&self) -> &[String] {
+        &self.vendored
+    }
+
+    /// Exact specifications of packages resolved outside the Pack.
+    pub fn unvendored(&self) -> &[String] {
+        &self.unvendored
+    }
+
+    fn is_empty(&self) -> bool {
+        self.vendored.is_empty() && self.unvendored.is_empty()
+    }
+}
+
+impl FontManifest {
+    /// The archive path containing this font's bytes.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// The face index within the font data.
+    pub fn index(&self) -> u32 {
+        self.index
+    }
+
+    /// Informational family names declared for this face.
+    pub fn families(&self) -> &[String] {
+        &self.families
+    }
+
+    pub(crate) fn new(path: String, index: u32, families: Vec<String>) -> Self {
+        Self {
+            path,
+            index,
+            families,
+        }
+    }
+}
+
+impl PackMetadata {
+    /// Creates empty Pack metadata.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the human-readable Pack name.
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Sets the Pack description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Adds a Pack author.
+    pub fn with_author(mut self, author: impl Into<String>) -> Self {
+        self.authors.push(author.into());
+        self
+    }
+
+    /// The human-readable Pack name.
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    /// The Pack description.
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    /// The Pack authors.
+    pub fn authors(&self) -> &[String] {
+        &self.authors
+    }
 }
 
 /// A manifest that could not be accepted.
@@ -98,54 +235,88 @@ pub struct PackMetadata {
 pub enum PackManifestError {
     #[error("failed to parse manifest: {0}")]
     Parse(#[from] toml::de::Error),
-    #[error("unsupported pack format version {0} (this reader supports up to {FORMAT_VERSION})")]
+    #[error("unsupported pack format version {0} (this reader supports version {FORMAT_VERSION})")]
     UnsupportedVersion(u32),
-    #[error("invalid entrypoint path `{path}`: {message}")]
-    InvalidEntrypoint { path: String, message: String },
-    #[error("invalid external project resource path `{path}`: {message}")]
-    InvalidExternalResource { path: String, message: String },
     #[error("invalid package spec `{spec}`: {message}")]
     InvalidPackageSpec { spec: String, message: String },
-    #[error("invalid font path `{path}`: {message}")]
-    InvalidFontPath { path: String, message: String },
 }
 
 impl PackManifest {
+    pub(crate) fn new(
+        entrypoint: String,
+        external_resources: BTreeSet<String>,
+        vendored_packages: Vec<String>,
+        external_packages: Vec<String>,
+        fonts: Vec<FontManifest>,
+        metadata: Option<PackMetadata>,
+    ) -> Self {
+        Self {
+            format_version: FORMAT_VERSION,
+            project: ProjectManifest {
+                entrypoint,
+                external_resources,
+            },
+            packages: PackagesManifest {
+                vendored: vendored_packages,
+                unvendored: external_packages,
+            },
+            fonts,
+            metadata,
+        }
+    }
+
+    /// The Pack format version.
+    pub fn format_version(&self) -> u32 {
+        self.format_version
+    }
+
+    /// The project declarations.
+    pub fn project(&self) -> &ProjectManifest {
+        &self.project
+    }
+
+    /// The package declarations.
+    pub fn packages(&self) -> &PackagesManifest {
+        &self.packages
+    }
+
+    /// The embedded font declarations.
+    pub fn fonts(&self) -> &[FontManifest] {
+        &self.fonts
+    }
+
+    /// Optional descriptive Pack metadata.
+    pub fn metadata(&self) -> Option<&PackMetadata> {
+        self.metadata.as_ref()
+    }
+
     /// Parses and validates a manifest from TOML text.
     pub fn from_toml(text: &str) -> Result<Self, PackManifestError> {
-        let mut manifest: PackManifest = toml::from_str(text)?;
-        manifest.normalize_external_resources();
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        struct VersionProbe {
+            format_version: u32,
+        }
+
+        let probe: VersionProbe = toml::from_str(text)?;
+        if probe.format_version != FORMAT_VERSION {
+            return Err(PackManifestError::UnsupportedVersion(probe.format_version));
+        }
+        let wire: Version1Manifest = toml::from_str(text)?;
+        let manifest = Self::from(wire);
         manifest.validate()?;
         Ok(manifest)
     }
 
     /// Serializes the manifest to TOML text.
     pub fn to_toml(&self) -> String {
-        let mut manifest = self.clone();
-        manifest.normalize_external_resources();
-        toml::to_string_pretty(&manifest).expect("manifest is always serializable")
+        toml::to_string_pretty(self).expect("manifest is always serializable")
     }
 
     /// Checks internal consistency of the manifest.
-    pub fn validate(&self) -> Result<(), PackManifestError> {
-        if self.format_version > FORMAT_VERSION {
+    fn validate(&self) -> Result<(), PackManifestError> {
+        if self.format_version != FORMAT_VERSION {
             return Err(PackManifestError::UnsupportedVersion(self.format_version));
-        }
-        self.entrypoint()?;
-        for path in &self.project.external_resources {
-            let virtual_path = VirtualPath::new(path).map_err(|err| {
-                PackManifestError::InvalidExternalResource {
-                    path: path.clone(),
-                    message: err.to_string(),
-                }
-            })?;
-            let canonical = virtual_path.get_without_slash();
-            if canonical != path {
-                return Err(PackManifestError::InvalidExternalResource {
-                    path: path.clone(),
-                    message: format!("path is not canonical; use `{canonical}`"),
-                });
-            }
         }
         for spec in self
             .packages
@@ -155,25 +326,7 @@ impl PackManifest {
         {
             parse_spec(spec)?;
         }
-        for font in &self.fonts {
-            if let Err(err) = VirtualPath::new(&font.path) {
-                return Err(PackManifestError::InvalidFontPath {
-                    path: font.path.clone(),
-                    message: err.to_string(),
-                });
-            }
-        }
         Ok(())
-    }
-
-    /// The entrypoint as a validated virtual path.
-    pub fn entrypoint(&self) -> Result<VirtualPath, PackManifestError> {
-        VirtualPath::new(&self.project.entrypoint).map_err(|err| {
-            PackManifestError::InvalidEntrypoint {
-                path: self.project.entrypoint.clone(),
-                message: err.to_string(),
-            }
-        })
     }
 
     /// The vendored package specs, parsed.
@@ -192,19 +345,6 @@ impl PackManifest {
             .iter()
             .map(|spec| parse_spec(spec))
             .collect()
-    }
-
-    fn normalize_external_resources(&mut self) {
-        self.project.external_resources = self
-            .project
-            .external_resources
-            .iter()
-            .map(|path| {
-                VirtualPath::new(path)
-                    .map(|path| path.get_without_slash().to_owned())
-                    .unwrap_or_else(|_| path.clone())
-            })
-            .collect();
     }
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -331,7 +331,11 @@ impl PackManifest {
 
     /// Parses and validates a manifest from TOML text.
     pub fn from_toml(text: &str) -> Result<Self, PackManifestError> {
-        parse_manifest_value(toml::from_str(text)?)
+        Self::from_toml_value(toml::from_str(text)?)
+    }
+
+    pub(crate) fn from_toml_value(value: toml::Value) -> Result<Self, PackManifestError> {
+        parse_manifest_value(value)
     }
 
     /// Serializes the manifest to TOML text.

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -168,24 +168,27 @@ impl Pack {
 
         let vendored_packages = manifest
             .vendored_packages()
-            .expect("accepted Pack Manifest contains valid package specifications")
-            .into_iter()
-            .map(|spec| spec.to_string())
-            .collect::<BTreeSet<_>>();
+            .iter()
+            .cloned()
+            .map(|spec| (spec.to_string(), spec))
+            .collect::<BTreeMap<_, _>>();
         let external_packages = manifest
             .unvendored_packages()
-            .expect("accepted Pack Manifest contains valid package specifications")
-            .into_iter()
-            .map(|spec| spec.to_string())
-            .collect::<BTreeSet<_>>();
-        if let Some(spec) = vendored_packages.intersection(&external_packages).next() {
+            .iter()
+            .cloned()
+            .map(|spec| (spec.to_string(), spec))
+            .collect::<BTreeMap<_, _>>();
+        if let Some(spec) = vendored_packages
+            .keys()
+            .find(|spec| external_packages.contains_key(*spec))
+        {
             return Err(PackInvariantError::PackageRoleConflict(spec.clone()));
         }
 
         let mut canonical_packages = BTreeMap::new();
         for (_, package) in packages {
             let key = package.spec.to_string();
-            if !vendored_packages.contains(&key) {
+            if !vendored_packages.contains_key(&key) {
                 return Err(PackInvariantError::UndeclaredPackageData(key));
             }
             let package_files = package.files;
@@ -214,7 +217,7 @@ impl Pack {
             );
         }
         if let Some(spec) = vendored_packages
-            .iter()
+            .keys()
             .find(|spec| !canonical_packages.contains_key(*spec))
         {
             return Err(PackInvariantError::MissingVendoredPackageData(spec.clone()));
@@ -227,9 +230,13 @@ impl Pack {
             let path = canonical_path(PackPathRole::FontData, entry.path())?;
             let conflicting_role = if path.as_str() == MANIFEST_PATH {
                 Some(PackPathRole::PackManifest)
-            } else if path.as_str().starts_with(PROJECT_PREFIX) {
+            } else if path.as_str() == PROJECT_PREFIX.trim_end_matches('/')
+                || path.as_str().starts_with(PROJECT_PREFIX)
+            {
                 Some(PackPathRole::ProjectFile)
-            } else if path.as_str().starts_with(PACKAGES_PREFIX) {
+            } else if path.as_str() == PACKAGES_PREFIX.trim_end_matches('/')
+                || path.as_str().starts_with(PACKAGES_PREFIX)
+            {
                 Some(PackPathRole::PackageFile)
             } else {
                 None
@@ -269,8 +276,8 @@ impl Pack {
                 .into_iter()
                 .map(CanonicalPath::into_string)
                 .collect(),
-            vendored_packages.into_iter().collect(),
-            external_packages.into_iter().collect(),
+            vendored_packages.into_values().collect(),
+            external_packages.into_values().collect(),
             canonical_fonts
                 .iter()
                 .map(|font| font.entry.clone())
@@ -378,6 +385,7 @@ impl Pack {
         struct UnknownEntry {
             index: usize,
             archive_name: String,
+            raw_name: Vec<u8>,
             canonical_name: String,
             regular_file: bool,
         }
@@ -387,9 +395,10 @@ impl Pack {
         let mut package_entries = Vec::new();
         let mut unknown_entries = Vec::new();
         let mut canonical_archive_entries = BTreeMap::new();
-        for index in 0..archive.len() {
+        for (index, raw_entry) in raw_entries.iter().enumerate() {
             let entry = archive.by_index_raw(index)?;
             let archive_name = entry.name().to_owned();
+            let raw_name = raw_entry.name.clone();
             let prefix_normalized_name = strip_current_directory_prefix(&archive_name);
             if archive_name.is_empty()
                 || archive_name.starts_with('/')
@@ -412,7 +421,7 @@ impl Pack {
             register_archive_identity(
                 &mut canonical_archive_entries,
                 canonical_name.clone(),
-                &archive_name,
+                &raw_name,
             )?;
             if entry.is_dir() {
                 continue;
@@ -436,7 +445,7 @@ impl Pack {
                 register_archive_identity(
                     &mut canonical_archive_entries,
                     MANIFEST_PATH.to_owned(),
-                    &archive_name,
+                    &raw_name,
                 )?;
                 manifest_entry = Some((index, regular_file));
             } else if let Some(path) = role_name.strip_prefix(PROJECT_PREFIX) {
@@ -447,7 +456,7 @@ impl Pack {
                 register_archive_identity(
                     &mut canonical_archive_entries,
                     format!("{PROJECT_PREFIX}{path}"),
-                    &archive_name,
+                    &raw_name,
                 )?;
                 project_entries.push(ProjectEntry { index, path });
             } else if let Some(rest) = role_name.strip_prefix(PACKAGES_PREFIX) {
@@ -461,13 +470,14 @@ impl Pack {
                         "{PACKAGES_PREFIX}{}/{}/{}/{path}",
                         spec.namespace, spec.name, spec.version
                     ),
-                    &archive_name,
+                    &raw_name,
                 )?;
                 package_entries.push(PackageEntry { index, spec, path });
             } else {
                 unknown_entries.push(UnknownEntry {
                     index,
                     archive_name,
+                    raw_name,
                     canonical_name,
                     regular_file,
                 });
@@ -503,7 +513,7 @@ impl Pack {
                 register_archive_identity(
                     &mut canonical_archive_entries,
                     path.to_string(),
-                    &entry.archive_name,
+                    &entry.raw_name,
                 )?;
                 font_entries.push((entry.index, path.clone()));
             }
@@ -751,11 +761,14 @@ impl PackBuilder {
     pub(crate) fn validate_declarations(&self) -> Result<(), PackBuildError> {
         let entrypoint = canonical_path(PackPathRole::Entrypoint, &self.entrypoint)?;
         if self.external_resources.contains(&entrypoint) {
-            return Err(
-                PackInvariantError::EntrypointIsExternalResource(entrypoint.to_string()).into(),
-            );
+            return Err(PackInvariantError::PathRoleConflict {
+                path: entrypoint.to_string(),
+                first: PackPathRole::ProjectFile,
+                second: PackPathRole::ExternalProjectResource,
+            }
+            .into());
         }
-        let mut project_paths = vec![(entrypoint, PackPathRole::Entrypoint)];
+        let mut project_paths = vec![(entrypoint, PackPathRole::ProjectFile)];
         project_paths.extend(
             self.external_resources
                 .iter()
@@ -846,11 +859,11 @@ impl PackBuilder {
                 .into_iter()
                 .map(CanonicalPath::into_string)
                 .collect(),
-            self.packages.keys().cloned().collect(),
-            self.unvendored_packages
-                .iter()
-                .map(ToString::to_string)
+            self.packages
+                .values()
+                .map(|package| package.spec.clone())
                 .collect(),
+            self.unvendored_packages.clone(),
             self.fonts.iter().map(|font| font.entry.clone()).collect(),
             self.metadata,
         );
@@ -966,22 +979,31 @@ fn find_path_tree_conflict(
 }
 
 fn register_archive_identity(
-    entries: &mut BTreeMap<String, String>,
+    entries: &mut BTreeMap<String, Vec<u8>>,
     canonical: String,
-    archive_name: &str,
+    raw_name: &[u8],
 ) -> Result<(), PackInvariantError> {
     if let Some(first_entry) = entries.get(&canonical) {
-        if first_entry == archive_name {
+        if first_entry == raw_name {
             return Ok(());
         }
         return Err(PackInvariantError::CanonicalArchiveEntryCollision {
             canonical,
-            first_entry: first_entry.clone(),
-            second_entry: archive_name.to_owned(),
+            first_entry: display_archive_name(first_entry),
+            second_entry: display_archive_name(raw_name),
         });
     }
-    entries.insert(canonical, archive_name.to_owned());
+    entries.insert(canonical, raw_name.to_owned());
     Ok(())
+}
+
+fn display_archive_name(raw_name: &[u8]) -> String {
+    String::from_utf8(raw_name.to_owned()).unwrap_or_else(|_| {
+        raw_name
+            .iter()
+            .flat_map(|byte| std::ascii::escape_default(*byte).map(char::from))
+            .collect()
+    })
 }
 
 /// A failure while building a pack in memory.

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -120,51 +120,12 @@ impl Pack {
             .external_resources()
             .map(|path| canonical_path(PackPathRole::ExternalProjectResource, path))
             .collect::<Result<BTreeSet<_>, _>>()?;
-
-        if let Some(path) = external_resources
+        let font_entries = manifest
+            .fonts()
             .iter()
-            .find(|path| canonical_files.contains_key(path.as_str()))
-        {
-            return Err(PackInvariantError::PathRoleConflict {
-                path: path.to_string(),
-                first: PackPathRole::ProjectFile,
-                second: PackPathRole::ExternalProjectResource,
-            });
-        }
-
-        let mut project_paths = canonical_files
-            .keys()
             .cloned()
-            .map(|path| (path, PackPathRole::ProjectFile))
-            .collect::<Vec<_>>();
-        project_paths.extend(
-            external_resources
-                .iter()
-                .cloned()
-                .map(|path| (path, PackPathRole::ExternalProjectResource)),
-        );
-        if let Some((ancestor, ancestor_role, descendant, descendant_role)) =
-            find_path_tree_conflict(project_paths)
-        {
-            return Err(PackInvariantError::PathTreeConflict {
-                ancestor: ancestor.to_string(),
-                ancestor_role,
-                descendant: descendant.to_string(),
-                descendant_role,
-                package: None,
-            });
-        }
-
-        if external_resources.contains(&entrypoint) {
-            return Err(PackInvariantError::EntrypointIsExternalResource(
-                entrypoint.to_string(),
-            ));
-        }
-        if !canonical_files.contains_key(&entrypoint) {
-            return Err(PackInvariantError::MissingEntrypoint(
-                entrypoint.to_string(),
-            ));
-        }
+            .map(|entry| Ok((canonical_path(PackPathRole::FontData, entry.path())?, entry)))
+            .collect::<Result<Vec<_>, PackInvariantError>>()?;
 
         let vendored_packages = manifest
             .vendored_packages()
@@ -185,14 +146,11 @@ impl Pack {
             return Err(PackInvariantError::PackageRoleConflict(spec.clone()));
         }
 
-        let mut canonical_packages = BTreeMap::new();
-        for (_, package) in packages {
-            let key = package.spec.to_string();
-            if !vendored_packages.contains_key(&key) {
-                return Err(PackInvariantError::UndeclaredPackageData(key));
-            }
-            let package_files = package.files;
-            let paths = package_files
+        validate_project_declarations(canonical_files.keys().cloned(), &external_resources)?;
+
+        for package in packages.values() {
+            let paths = package
+                .files
                 .keys()
                 .cloned()
                 .map(|path| (path, PackPathRole::PackageFile))
@@ -200,14 +158,60 @@ impl Pack {
             if let Some((ancestor, ancestor_role, descendant, descendant_role)) =
                 find_path_tree_conflict(paths)
             {
-                return Err(PackInvariantError::PathTreeConflict {
+                return Err(PackInvariantError::PackagePathTreeConflict {
+                    package: package.spec.to_string(),
                     ancestor: ancestor.to_string(),
                     ancestor_role,
                     descendant: descendant.to_string(),
                     descendant_role,
-                    package: Some(key),
                 });
             }
+        }
+
+        for (path, _) in &font_entries {
+            if let Some(conflicting_role) = reserved_font_path_role(path) {
+                return Err(PackInvariantError::ReservedFontPath {
+                    path: path.to_string(),
+                    conflicting_role,
+                });
+            }
+        }
+        let font_paths = font_entries
+            .iter()
+            .map(|(path, _)| path.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .map(|path| (path, PackPathRole::FontData))
+            .collect();
+        if let Some((ancestor, ancestor_role, descendant, descendant_role)) =
+            find_path_tree_conflict(font_paths)
+        {
+            return Err(PackInvariantError::PathTreeConflict {
+                ancestor: ancestor.to_string(),
+                ancestor_role,
+                descendant: descendant.to_string(),
+                descendant_role,
+            });
+        }
+
+        if external_resources.contains(&entrypoint) {
+            return Err(PackInvariantError::EntrypointIsExternalResource(
+                entrypoint.to_string(),
+            ));
+        }
+        if !canonical_files.contains_key(&entrypoint) {
+            return Err(PackInvariantError::MissingEntrypoint(
+                entrypoint.to_string(),
+            ));
+        }
+
+        let mut canonical_packages = BTreeMap::new();
+        for (_, package) in packages {
+            let key = package.spec.to_string();
+            if !vendored_packages.contains_key(&key) {
+                return Err(PackInvariantError::UndeclaredPackageData(key));
+            }
+            let package_files = package.files;
             canonical_packages.insert(
                 key,
                 PackageFiles {
@@ -223,30 +227,9 @@ impl Pack {
             return Err(PackInvariantError::MissingVendoredPackageData(spec.clone()));
         }
 
-        let canonical_font_data = font_data;
         let mut canonical_fonts = Vec::new();
         let mut font_faces = BTreeSet::new();
-        for entry in manifest.fonts() {
-            let path = canonical_path(PackPathRole::FontData, entry.path())?;
-            let conflicting_role = if path.as_str() == MANIFEST_PATH {
-                Some(PackPathRole::PackManifest)
-            } else if path.as_str() == PROJECT_PREFIX.trim_end_matches('/')
-                || path.as_str().starts_with(PROJECT_PREFIX)
-            {
-                Some(PackPathRole::ProjectFile)
-            } else if path.as_str() == PACKAGES_PREFIX.trim_end_matches('/')
-                || path.as_str().starts_with(PACKAGES_PREFIX)
-            {
-                Some(PackPathRole::PackageFile)
-            } else {
-                None
-            };
-            if let Some(conflicting_role) = conflicting_role {
-                return Err(PackInvariantError::ReservedFontPath {
-                    path: path.to_string(),
-                    conflicting_role,
-                });
-            }
+        for (path, entry) in font_entries {
             let index = entry.index();
             if !font_faces.insert((path.clone(), index)) {
                 return Err(PackInvariantError::DuplicateFontFace {
@@ -254,15 +237,16 @@ impl Pack {
                     index,
                 });
             }
-            let data = canonical_font_data
+            let data = font_data
                 .get(&path)
                 .cloned()
                 .ok_or_else(|| PackInvariantError::MissingFontData(path.to_string()))?;
-            let parsed =
-                Font::new(data.clone(), index).ok_or_else(|| PackInvariantError::InvalidFont {
-                    path: Some(path.to_string()),
+            let parsed = Font::new(data.clone(), index).ok_or_else(|| {
+                PackInvariantError::InvalidFontData {
+                    path: path.to_string(),
                     index,
-                })?;
+                }
+            })?;
             canonical_fonts.push(PackFont {
                 entry: FontManifest::new(path.into_string(), index, entry.families().to_vec()),
                 data,
@@ -760,33 +744,7 @@ impl PackBuilder {
     #[cfg(feature = "fs")]
     pub(crate) fn validate_declarations(&self) -> Result<(), PackBuildError> {
         let entrypoint = canonical_path(PackPathRole::Entrypoint, &self.entrypoint)?;
-        if self.external_resources.contains(&entrypoint) {
-            return Err(PackInvariantError::PathRoleConflict {
-                path: entrypoint.to_string(),
-                first: PackPathRole::ProjectFile,
-                second: PackPathRole::ExternalProjectResource,
-            }
-            .into());
-        }
-        let mut project_paths = vec![(entrypoint, PackPathRole::ProjectFile)];
-        project_paths.extend(
-            self.external_resources
-                .iter()
-                .cloned()
-                .map(|path| (path, PackPathRole::ExternalProjectResource)),
-        );
-        if let Some((ancestor, ancestor_role, descendant, descendant_role)) =
-            find_path_tree_conflict(project_paths)
-        {
-            return Err(PackInvariantError::PathTreeConflict {
-                ancestor: ancestor.to_string(),
-                ancestor_role,
-                descendant: descendant.to_string(),
-                descendant_role,
-                package: None,
-            }
-            .into());
-        }
+        validate_project_declarations(std::iter::once(entrypoint), &self.external_resources)?;
         Ok(())
     }
 
@@ -823,8 +781,8 @@ impl PackBuilder {
     /// entry name and family list are derived from the font data.
     pub fn font(mut self, data: impl Into<Vec<u8>>, index: u32) -> Result<Self, PackBuildError> {
         let data = data.into();
-        let info = FontInfo::new(&data, index)
-            .ok_or(PackInvariantError::InvalidFont { path: None, index })?;
+        let info =
+            FontInfo::new(&data, index).ok_or(PackInvariantError::InvalidFontInput { index })?;
         let family = info.family.to_string();
         let path = self.font_path(&family, &data);
         self.fonts.push(PackFontInput {
@@ -978,6 +936,59 @@ fn find_path_tree_conflict(
     None
 }
 
+fn validate_project_declarations(
+    project_files: impl IntoIterator<Item = CanonicalPath>,
+    external_resources: &BTreeSet<CanonicalPath>,
+) -> Result<(), PackInvariantError> {
+    let mut project_paths = Vec::new();
+    for path in project_files {
+        if external_resources.contains(&path) {
+            return Err(PackInvariantError::PathRoleConflict {
+                path: path.to_string(),
+                first: PackPathRole::ProjectFile,
+                second: PackPathRole::ExternalProjectResource,
+            });
+        }
+        project_paths.push((path, PackPathRole::ProjectFile));
+    }
+    project_paths.extend(
+        external_resources
+            .iter()
+            .cloned()
+            .map(|path| (path, PackPathRole::ExternalProjectResource)),
+    );
+    if let Some((ancestor, ancestor_role, descendant, descendant_role)) =
+        find_path_tree_conflict(project_paths)
+    {
+        return Err(PackInvariantError::PathTreeConflict {
+            ancestor: ancestor.to_string(),
+            ancestor_role,
+            descendant: descendant.to_string(),
+            descendant_role,
+        });
+    }
+    Ok(())
+}
+
+fn reserved_font_path_role(path: &CanonicalPath) -> Option<PackPathRole> {
+    if is_same_or_descendant(path.as_str(), MANIFEST_PATH) {
+        Some(PackPathRole::PackManifest)
+    } else if is_same_or_descendant(path.as_str(), PROJECT_PREFIX.trim_end_matches('/')) {
+        Some(PackPathRole::ProjectFile)
+    } else if is_same_or_descendant(path.as_str(), PACKAGES_PREFIX.trim_end_matches('/')) {
+        Some(PackPathRole::PackageFile)
+    } else {
+        None
+    }
+}
+
+fn is_same_or_descendant(path: &str, ancestor: &str) -> bool {
+    path == ancestor
+        || path
+            .strip_prefix(ancestor)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
 fn register_archive_identity(
     entries: &mut BTreeMap<String, Vec<u8>>,
     canonical: String,
@@ -1039,14 +1050,24 @@ pub enum PackInvariantError {
     },
     /// One file path is an ancestor of another file path in the same tree.
     #[error(
-        "{ancestor_role} path `{ancestor}` conflicts with {descendant_role} descendant `{descendant}` (package: {package:?})"
+        "{ancestor_role} path `{ancestor}` conflicts with {descendant_role} descendant `{descendant}`"
     )]
     PathTreeConflict {
         ancestor: String,
         ancestor_role: PackPathRole,
         descendant: String,
         descendant_role: PackPathRole,
-        package: Option<String>,
+    },
+    /// One package file path is an ancestor of another file path in that package.
+    #[error(
+        "package `{package}` {ancestor_role} path `{ancestor}` conflicts with {descendant_role} descendant `{descendant}`"
+    )]
+    PackagePathTreeConflict {
+        package: String,
+        ancestor: String,
+        ancestor_role: PackPathRole,
+        descendant: String,
+        descendant_role: PackPathRole,
     },
     /// The entrypoint was declared as a non-source External Project Resource.
     #[error("entrypoint `{0}` cannot be an External Project Resource")]
@@ -1069,9 +1090,12 @@ pub enum PackInvariantError {
     /// A font declaration has no contained bytes.
     #[error("font data `{0}` is missing")]
     MissingFontData(String),
+    /// Builder-provided font bytes do not contain the requested face.
+    #[error("font input does not contain a valid face at index {index}")]
+    InvalidFontInput { index: u32 },
     /// Contained font bytes do not contain the declared face.
-    #[error("font data {path:?} does not contain a valid face at index {index}")]
-    InvalidFont { path: Option<String>, index: u32 },
+    #[error("font data `{path}` does not contain a valid face at index {index}")]
+    InvalidFontData { path: String, index: u32 },
     /// The same contained font face was declared more than once.
     #[error("font `{path}` declares face index {index} more than once")]
     DuplicateFontFace { path: String, index: u32 },

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -19,6 +19,7 @@ pub const FILE_EXTENSION: &str = "typk";
 
 const PROJECT_PREFIX: &str = "project/";
 const PACKAGES_PREFIX: &str = "packages/";
+const MAX_ZIP_ENTRY_NAME_LEN: usize = u16::MAX as usize;
 
 /// A portable pack of a Typst project.
 ///
@@ -147,11 +148,28 @@ impl Pack {
             .cloned()
             .map(|spec| (spec.to_string(), spec))
             .collect::<BTreeMap<_, _>>();
-        if let Some(spec) = vendored_packages
-            .keys()
-            .find(|spec| external_packages.contains_key(*spec))
-        {
-            return Err(PackInvariantError::PackageRoleConflict(spec.clone()));
+        for path in canonical_files.keys() {
+            validate_archive_entry_name(
+                PackPathRole::ProjectFile,
+                path,
+                PROJECT_PREFIX.len() + path.as_str().len(),
+            )?;
+        }
+        for package in packages.values() {
+            let spec = &package.spec;
+            let version = spec.version.to_string();
+            let package_prefix_len =
+                PACKAGES_PREFIX.len() + spec.namespace.len() + spec.name.len() + version.len() + 3;
+            for path in package.files.keys() {
+                validate_archive_entry_name(
+                    PackPathRole::PackageFile,
+                    path,
+                    package_prefix_len + path.as_str().len(),
+                )?;
+            }
+        }
+        for (path, _) in &font_entries {
+            validate_archive_entry_name(PackPathRole::FontData, path, path.as_str().len())?;
         }
 
         validate_project_declarations(canonical_files.keys().cloned(), &external_resources)?;
@@ -197,6 +215,12 @@ impl Pack {
                 descendant_role: conflict.descendant_role,
             });
         }
+        if let Some(spec) = vendored_packages
+            .keys()
+            .find(|spec| external_packages.contains_key(*spec))
+        {
+            return Err(PackInvariantError::PackageRoleConflict(spec.clone()));
+        }
 
         if external_resources.contains(&entrypoint) {
             return Err(PackInvariantError::EntrypointIsExternalResource(
@@ -207,6 +231,15 @@ impl Pack {
             return Err(PackInvariantError::MissingEntrypoint(
                 entrypoint.to_string(),
             ));
+        }
+
+        for spec in manifest
+            .vendored_packages()
+            .iter()
+            .chain(manifest.unvendored_packages())
+            .chain(packages.values().map(|package| &package.spec))
+        {
+            validate_package_spec(spec)?;
         }
 
         let mut canonical_packages = BTreeMap::new();
@@ -347,18 +380,6 @@ impl Pack {
         let central_directory_start = archive.central_directory_start();
         let mut reader = archive.into_inner();
         let raw_entries = raw_central_entries(&mut reader, central_directory_start)?;
-        let mut raw_names = BTreeSet::new();
-        for entry in &raw_entries {
-            if !raw_names.insert(entry.name.clone()) {
-                if entry.name == MANIFEST_PATH.as_bytes() {
-                    return Err(PackReadError::DuplicateManifest);
-                }
-                return Err(PackReadError::DuplicateArchiveEntry(entry.name.clone()));
-            }
-        }
-        if raw_entries.len() != retained_entry_count {
-            return Err(PackReadError::AmbiguousArchiveEntries);
-        }
         let mut archive = ZipArchive::new(reader)?;
         const FILE_TYPE_MASK: u32 = 0o170000;
         const REGULAR_FILE: u32 = 0o100000;
@@ -366,7 +387,11 @@ impl Pack {
         let mut manifest_entry = None;
         for index in 0..archive.len() {
             let entry = archive.by_index_raw(index)?;
-            if strip_current_directory_prefix(entry.name()) == MANIFEST_PATH {
+            let prefix_normalized_name = strip_current_directory_prefix(entry.name());
+            let canonical_manifest_alias = !prefix_normalized_name.starts_with(PROJECT_PREFIX)
+                && !prefix_normalized_name.starts_with(PACKAGES_PREFIX)
+                && canonical_archive_name(entry.name()).is_ok_and(|name| name == MANIFEST_PATH);
+            if prefix_normalized_name == MANIFEST_PATH || canonical_manifest_alias {
                 let regular_file = entry.is_file()
                     && entry
                         .unix_mode()
@@ -380,15 +405,29 @@ impl Pack {
         if !manifest_is_file {
             return Err(PackReadError::ManifestNotFile);
         }
-        let manifest = {
+        let manifest_value = {
             let mut entry = archive.by_index(manifest_index)?;
             let mut bytes = Vec::new();
             entry
                 .read_to_end(&mut bytes)
                 .map_err(PackReadError::ManifestUnreadable)?;
             let text = std::str::from_utf8(&bytes).map_err(PackReadError::ManifestNotUtf8)?;
-            PackManifest::from_toml(text)?
+            toml::from_str::<toml::Value>(text).map_err(PackManifestError::from)?
         };
+
+        let mut raw_names = BTreeSet::new();
+        for entry in &raw_entries {
+            if !raw_names.insert(entry.name.clone()) {
+                if entry.name == MANIFEST_PATH.as_bytes() {
+                    return Err(PackReadError::DuplicateManifest);
+                }
+                return Err(PackReadError::DuplicateArchiveEntry(entry.name.clone()));
+            }
+        }
+        if raw_entries.len() != retained_entry_count {
+            return Err(PackReadError::AmbiguousArchiveEntries);
+        }
+        let manifest = PackManifest::from_toml_value(manifest_value)?;
 
         struct ProjectEntry {
             index: usize,
@@ -416,22 +455,7 @@ impl Pack {
             let archive_name = entry.name().to_owned();
             let raw_name = raw_entry.name.clone();
             let prefix_normalized_name = strip_current_directory_prefix(&archive_name);
-            if archive_name.is_empty()
-                || archive_name.starts_with('/')
-                || archive_name.starts_with('\\')
-                || archive_name.contains('\\')
-                || archive_name.contains('\0')
-                || has_windows_drive_prefix(prefix_normalized_name)
-            {
-                return Err(PackReadError::UnsafeEntry(archive_name));
-            }
-            let canonical_name = VirtualPath::new(&archive_name)
-                .map_err(|_| PackReadError::UnsafeEntry(archive_name.clone()))?
-                .get_without_slash()
-                .to_owned();
-            if has_windows_drive_prefix(&canonical_name) {
-                return Err(PackReadError::UnsafeEntry(archive_name));
-            }
+            let canonical_name = canonical_archive_name(&archive_name)?;
             register_archive_identity(
                 &mut canonical_archive_entries,
                 canonical_name.clone(),
@@ -463,7 +487,7 @@ impl Pack {
                 if !regular_file {
                     return Err(PackReadError::UnsupportedEntryType(archive_name));
                 }
-                let path = canonical_path(PackPathRole::ProjectFile, path)?;
+                let path = canonical_path(PackPathRole::ProjectFile, path.trim_start_matches('/'))?;
                 register_archive_identity(
                     &mut canonical_archive_entries,
                     format!("{PROJECT_PREFIX}{path}"),
@@ -552,14 +576,16 @@ impl Pack {
     /// Writes the pack archive to a seekable writer.
     pub fn write<W: Write + Seek>(&self, writer: W) -> Result<(), PackWriteError> {
         let mut zip = ZipWriter::new(writer);
-        let options =
-            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        let manifest = self.manifest.to_toml();
 
-        zip.start_file(MANIFEST_PATH, options)?;
-        zip.write_all(self.manifest.to_toml().as_bytes())?;
+        zip.start_file(MANIFEST_PATH, zip_file_options(manifest.len()))?;
+        zip.write_all(manifest.as_bytes())?;
 
         for (path, data) in &self.files {
-            zip.start_file(format!("{PROJECT_PREFIX}{path}"), options)?;
+            zip.start_file(
+                format!("{PROJECT_PREFIX}{path}"),
+                zip_file_options(data.len()),
+            )?;
             zip.write_all(data)?;
         }
 
@@ -571,7 +597,7 @@ impl Pack {
                         "{PACKAGES_PREFIX}{}/{}/{}/{path}",
                         spec.namespace, spec.name, spec.version
                     ),
-                    options,
+                    zip_file_options(data.len()),
                 )?;
                 zip.write_all(data)?;
             }
@@ -580,7 +606,7 @@ impl Pack {
         let mut written = std::collections::BTreeSet::new();
         for font in &self.fonts {
             if written.insert(font.manifest().path()) {
-                zip.start_file(font.manifest().path(), options)?;
+                zip.start_file(font.manifest().path(), zip_file_options(font.data().len()))?;
                 zip.write_all(font.data())?;
             }
         }
@@ -595,6 +621,16 @@ impl Pack {
         self.write(&mut buffer)?;
         Ok(buffer.into_inner())
     }
+}
+
+fn zip_file_options(size: usize) -> SimpleFileOptions {
+    // Deflate may expand incompressible input. Nine bits per input byte plus
+    // framing is a conservative bound for the configured encoder.
+    let compressed_bound = size.saturating_add(size.div_ceil(8)).saturating_add(16);
+    let compressed_bound = u64::try_from(compressed_bound).unwrap_or(u64::MAX);
+    SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .large_file(compressed_bound > zip::ZIP64_BYTES_THR)
 }
 
 struct RawCentralEntry {
@@ -649,7 +685,7 @@ fn split_package_entry(
             message: err.to_string(),
         }
     })?;
-    let path = canonical_path(PackPathRole::PackageFile, path)?;
+    let path = canonical_path(PackPathRole::PackageFile, path.trim_start_matches('/'))?;
     Ok((spec, path))
 }
 
@@ -917,6 +953,58 @@ fn canonical_path(role: PackPathRole, path: &str) -> Result<CanonicalPath, PackI
     Ok(CanonicalPath(canonical.to_owned()))
 }
 
+fn canonical_archive_name(path: &str) -> Result<String, PackReadError> {
+    let prefix_normalized_path = strip_current_directory_prefix(path);
+    if path.is_empty()
+        || path.starts_with('/')
+        || path.starts_with('\\')
+        || path.contains('\\')
+        || path.contains('\0')
+        || has_windows_drive_prefix(prefix_normalized_path)
+    {
+        return Err(PackReadError::UnsafeEntry(path.to_owned()));
+    }
+    let canonical = VirtualPath::new(path)
+        .map_err(|_| PackReadError::UnsafeEntry(path.to_owned()))?
+        .get_without_slash()
+        .to_owned();
+    if has_windows_drive_prefix(&canonical) {
+        return Err(PackReadError::UnsafeEntry(path.to_owned()));
+    }
+    Ok(canonical)
+}
+
+fn validate_package_spec(spec: &PackageSpec) -> Result<(), PackInvariantError> {
+    let serialized = spec.to_string();
+    let parsed = PackageSpec::from_str(&serialized).map_err(|message| {
+        PackInvariantError::InvalidPackageSpec {
+            spec: serialized.clone(),
+            message: message.to_string(),
+        }
+    })?;
+    if parsed != *spec {
+        return Err(PackInvariantError::InvalidPackageSpec {
+            spec: serialized,
+            message: "package specification does not round-trip canonically".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_archive_entry_name(
+    role: PackPathRole,
+    path: &CanonicalPath,
+    archive_name_len: usize,
+) -> Result<(), PackInvariantError> {
+    if archive_name_len > MAX_ZIP_ENTRY_NAME_LEN {
+        return Err(PackInvariantError::ArchiveEntryNameTooLong {
+            role,
+            path: path.to_string(),
+        });
+    }
+    Ok(())
+}
+
 fn has_windows_drive_prefix(path: &str) -> bool {
     let bytes = path.as_bytes();
     bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
@@ -1049,6 +1137,12 @@ pub enum PackInvariantError {
         path: String,
         message: String,
     },
+    /// A package value cannot be represented as a canonical package specification.
+    #[error("invalid package spec `{spec}`: {message}")]
+    InvalidPackageSpec { spec: String, message: String },
+    /// A contained path cannot fit in ZIP's filename field after adding its role prefix.
+    #[error("the {role} path `{path}` exceeds ZIP's filename length limit")]
+    ArchiveEntryNameTooLong { role: PackPathRole, path: String },
     /// Distinct archive entries identify one canonical contained file.
     #[error("archive entries `{first_entry}` and `{second_entry}` both identify `{canonical}`")]
     CanonicalArchiveEntryCollision {

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -44,6 +44,14 @@ struct PackageFiles {
 #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
 struct CanonicalPath(String);
 
+#[derive(Debug)]
+struct PathTreeConflict {
+    ancestor: CanonicalPath,
+    ancestor_role: PackPathRole,
+    descendant: CanonicalPath,
+    descendant_role: PackPathRole,
+}
+
 impl CanonicalPath {
     fn as_str(&self) -> &str {
         &self.0
@@ -155,15 +163,13 @@ impl Pack {
                 .cloned()
                 .map(|path| (path, PackPathRole::PackageFile))
                 .collect();
-            if let Some((ancestor, ancestor_role, descendant, descendant_role)) =
-                find_path_tree_conflict(paths)
-            {
+            if let Some(conflict) = find_path_tree_conflict(paths) {
                 return Err(PackInvariantError::PackagePathTreeConflict {
                     package: package.spec.to_string(),
-                    ancestor: ancestor.to_string(),
-                    ancestor_role,
-                    descendant: descendant.to_string(),
-                    descendant_role,
+                    ancestor: conflict.ancestor.to_string(),
+                    ancestor_role: conflict.ancestor_role,
+                    descendant: conflict.descendant.to_string(),
+                    descendant_role: conflict.descendant_role,
                 });
             }
         }
@@ -183,14 +189,12 @@ impl Pack {
             .into_iter()
             .map(|path| (path, PackPathRole::FontData))
             .collect();
-        if let Some((ancestor, ancestor_role, descendant, descendant_role)) =
-            find_path_tree_conflict(font_paths)
-        {
+        if let Some(conflict) = find_path_tree_conflict(font_paths) {
             return Err(PackInvariantError::PathTreeConflict {
-                ancestor: ancestor.to_string(),
-                ancestor_role,
-                descendant: descendant.to_string(),
-                descendant_role,
+                ancestor: conflict.ancestor.to_string(),
+                ancestor_role: conflict.ancestor_role,
+                descendant: conflict.descendant.to_string(),
+                descendant_role: conflict.descendant_role,
             });
         }
 
@@ -416,16 +420,14 @@ impl Pack {
                 || archive_name.starts_with('/')
                 || archive_name.starts_with('\\')
                 || archive_name.contains('\\')
+                || archive_name.contains('\0')
                 || has_windows_drive_prefix(prefix_normalized_name)
             {
                 return Err(PackReadError::UnsafeEntry(archive_name));
             }
-            let enclosed_name = entry
-                .enclosed_name()
-                .ok_or_else(|| PackReadError::UnsafeEntry(archive_name.clone()))?;
-            let canonical_name = enclosed_name
-                .to_str()
-                .ok_or_else(|| PackReadError::UnsafeEntry(archive_name.clone()))?
+            let canonical_name = VirtualPath::new(&archive_name)
+                .map_err(|_| PackReadError::UnsafeEntry(archive_name.clone()))?
+                .get_without_slash()
                 .to_owned();
             if has_windows_drive_prefix(&canonical_name) {
                 return Err(PackReadError::UnsafeEntry(archive_name));
@@ -929,7 +931,7 @@ fn strip_current_directory_prefix(mut path: &str) -> &str {
 
 fn find_path_tree_conflict(
     mut paths: Vec<(CanonicalPath, PackPathRole)>,
-) -> Option<(CanonicalPath, PackPathRole, CanonicalPath, PackPathRole)> {
+) -> Option<PathTreeConflict> {
     paths.sort_by(|(left, _), (right, _)| left.cmp(right));
     for (ancestor, ancestor_role) in &paths {
         let prefix = format!("{ancestor}/");
@@ -937,12 +939,12 @@ fn find_path_tree_conflict(
         if let Some((descendant, descendant_role)) = paths.get(candidate)
             && descendant.as_str().starts_with(&prefix)
         {
-            return Some((
-                ancestor.clone(),
-                *ancestor_role,
-                descendant.clone(),
-                *descendant_role,
-            ));
+            return Some(PathTreeConflict {
+                ancestor: ancestor.clone(),
+                ancestor_role: *ancestor_role,
+                descendant: descendant.clone(),
+                descendant_role: *descendant_role,
+            });
         }
     }
     None
@@ -969,14 +971,12 @@ fn validate_project_declarations(
             .cloned()
             .map(|path| (path, PackPathRole::ExternalProjectResource)),
     );
-    if let Some((ancestor, ancestor_role, descendant, descendant_role)) =
-        find_path_tree_conflict(project_paths)
-    {
+    if let Some(conflict) = find_path_tree_conflict(project_paths) {
         return Err(PackInvariantError::PathTreeConflict {
-            ancestor: ancestor.to_string(),
-            ancestor_role,
-            descendant: descendant.to_string(),
-            descendant_role,
+            ancestor: conflict.ancestor.to_string(),
+            ancestor_role: conflict.ancestor_role,
+            descendant: conflict.descendant.to_string(),
+            descendant_role: conflict.descendant_role,
         });
     }
     Ok(())

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -356,6 +356,35 @@ impl Pack {
             return Err(PackReadError::AmbiguousArchiveEntries);
         }
         let mut archive = ZipArchive::new(reader)?;
+        const FILE_TYPE_MASK: u32 = 0o170000;
+        const REGULAR_FILE: u32 = 0o100000;
+
+        let mut manifest_entry = None;
+        for index in 0..archive.len() {
+            let entry = archive.by_index_raw(index)?;
+            if strip_current_directory_prefix(entry.name()) == MANIFEST_PATH {
+                let regular_file = entry.is_file()
+                    && entry
+                        .unix_mode()
+                        .is_none_or(|mode| matches!(mode & FILE_TYPE_MASK, 0 | REGULAR_FILE));
+                manifest_entry = Some((index, regular_file));
+                break;
+            }
+        }
+        let (manifest_index, manifest_is_file) =
+            manifest_entry.ok_or(PackReadError::MissingManifest)?;
+        if !manifest_is_file {
+            return Err(PackReadError::ManifestNotFile);
+        }
+        let manifest = {
+            let mut entry = archive.by_index(manifest_index)?;
+            let mut bytes = Vec::new();
+            entry
+                .read_to_end(&mut bytes)
+                .map_err(PackReadError::ManifestUnreadable)?;
+            let text = std::str::from_utf8(&bytes).map_err(PackReadError::ManifestNotUtf8)?;
+            PackManifest::from_toml(text)?
+        };
 
         struct ProjectEntry {
             index: usize,
@@ -374,7 +403,6 @@ impl Pack {
             regular_file: bool,
         }
 
-        let mut manifest_entry = None;
         let mut project_entries = Vec::new();
         let mut package_entries = Vec::new();
         let mut unknown_entries = Vec::new();
@@ -410,8 +438,6 @@ impl Pack {
             if entry.is_dir() {
                 continue;
             }
-            const FILE_TYPE_MASK: u32 = 0o170000;
-            const REGULAR_FILE: u32 = 0o100000;
             let regular_file = entry.is_file()
                 && entry
                     .unix_mode()
@@ -431,7 +457,6 @@ impl Pack {
                     MANIFEST_PATH.to_owned(),
                     &raw_name,
                 )?;
-                manifest_entry = Some((index, regular_file));
             } else if let Some(path) = role_name.strip_prefix(PROJECT_PREFIX) {
                 if !regular_file {
                     return Err(PackReadError::UnsupportedEntryType(archive_name));
@@ -467,21 +492,6 @@ impl Pack {
                 });
             }
         }
-
-        let (manifest_index, manifest_is_file) =
-            manifest_entry.ok_or(PackReadError::MissingManifest)?;
-        if !manifest_is_file {
-            return Err(PackReadError::ManifestNotFile);
-        }
-        let manifest = {
-            let mut entry = archive.by_index(manifest_index)?;
-            let mut bytes = Vec::new();
-            entry
-                .read_to_end(&mut bytes)
-                .map_err(PackReadError::ManifestUnreadable)?;
-            let text = std::str::from_utf8(&bytes).map_err(PackReadError::ManifestNotUtf8)?;
-            PackManifest::from_toml(text)?
-        };
 
         let font_paths = manifest
             .fonts()
@@ -781,8 +791,7 @@ impl PackBuilder {
     /// entry name and family list are derived from the font data.
     pub fn font(mut self, data: impl Into<Vec<u8>>, index: u32) -> Result<Self, PackBuildError> {
         let data = data.into();
-        let info =
-            FontInfo::new(&data, index).ok_or(PackInvariantError::InvalidFontInput { index })?;
+        let info = FontInfo::new(&data, index).ok_or(PackBuildError::InvalidFontInput { index })?;
         let family = info.family.to_string();
         let path = self.font_path(&family, &data);
         self.fonts.push(PackFontInput {
@@ -884,6 +893,9 @@ fn canonical_path(role: PackPathRole, path: &str) -> Result<CanonicalPath, PackI
         return Err(invalid(
             "backslashes are not portable path separators".to_owned(),
         ));
+    }
+    if path.contains('\0') {
+        return Err(invalid("path must not contain NUL bytes".to_owned()));
     }
     if has_windows_drive_prefix(path) {
         return Err(invalid(
@@ -1020,6 +1032,9 @@ fn display_archive_name(raw_name: &[u8]) -> String {
 /// A failure while building a pack in memory.
 #[derive(Debug, thiserror::Error)]
 pub enum PackBuildError {
+    /// Builder-provided font bytes do not contain the requested face.
+    #[error("font input does not contain a valid face at index {index}")]
+    InvalidFontInput { index: u32 },
     #[error(transparent)]
     Invariant(#[from] PackInvariantError),
 }
@@ -1090,9 +1105,6 @@ pub enum PackInvariantError {
     /// A font declaration has no contained bytes.
     #[error("font data `{0}` is missing")]
     MissingFontData(String),
-    /// Builder-provided font bytes do not contain the requested face.
-    #[error("font input does not contain a valid face at index {index}")]
-    InvalidFontInput { index: u32 },
     /// Contained font bytes do not contain the declared face.
     #[error("font data `{path}` does not contain a valid face at index {index}")]
     InvalidFontData { path: String, index: u32 },

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,20 +1,18 @@
 //! The in-memory pack model and its archive serialization.
 
+use std::borrow::Borrow;
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::{Cursor, Read, Seek, Write};
+use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use std::str::FromStr;
 
 use typst::foundations::Bytes;
 use typst::syntax::VirtualPath;
 use typst::syntax::package::PackageSpec;
-use typst::text::FontInfo;
+use typst::text::{Font, FontInfo};
 use zip::write::SimpleFileOptions;
 use zip::{ZipArchive, ZipWriter};
 
-use crate::manifest::{
-    FORMAT_VERSION, FontManifest, MANIFEST_PATH, PackManifest, PackManifestError, PackMetadata,
-    PackagesManifest, ProjectManifest,
-};
+use crate::manifest::{FontManifest, MANIFEST_PATH, PackManifest, PackManifestError, PackMetadata};
 
 /// The conventional file extension for packs.
 pub const FILE_EXTENSION: &str = "typk";
@@ -31,7 +29,7 @@ const PACKAGES_PREFIX: &str = "packages/";
 #[derive(Debug, Clone)]
 pub struct Pack {
     manifest: PackManifest,
-    files: BTreeMap<String, Bytes>,
+    files: BTreeMap<CanonicalPath, Bytes>,
     /// Vendored packages, keyed by spec string for deterministic order.
     packages: BTreeMap<String, PackageFiles>,
     fonts: Vec<PackFont>,
@@ -40,16 +38,64 @@ pub struct Pack {
 #[derive(Debug, Clone)]
 struct PackageFiles {
     spec: PackageSpec,
-    files: BTreeMap<String, Bytes>,
+    files: BTreeMap<CanonicalPath, Bytes>,
+}
+
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+struct CanonicalPath(String);
+
+impl CanonicalPath {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl Borrow<str> for CanonicalPath {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for CanonicalPath {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
 }
 
 /// A font embedded in a pack.
 #[derive(Debug, Clone)]
 pub struct PackFont {
     /// The manifest entry describing this font.
-    pub entry: FontManifest,
+    entry: FontManifest,
     /// The raw font file data.
-    pub data: Bytes,
+    data: Bytes,
+    font: Font,
+}
+
+impl PackFont {
+    /// The declaration describing this font face.
+    pub fn manifest(&self) -> &FontManifest {
+        &self.entry
+    }
+
+    /// The contained font bytes.
+    pub fn data(&self) -> &Bytes {
+        &self.data
+    }
+
+    pub(crate) fn font(&self) -> &Font {
+        &self.font
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PackFontInput {
+    entry: FontManifest,
+    data: Bytes,
 }
 
 impl Pack {
@@ -61,6 +107,185 @@ impl Pack {
         PackBuilder::new(entrypoint)
     }
 
+    fn construct(
+        manifest: PackManifest,
+        files: BTreeMap<CanonicalPath, Bytes>,
+        packages: BTreeMap<String, PackageFiles>,
+        font_data: BTreeMap<CanonicalPath, Bytes>,
+    ) -> Result<Self, PackInvariantError> {
+        let entrypoint = canonical_path(PackPathRole::Entrypoint, manifest.project().entrypoint())?;
+        let canonical_files = files;
+        let external_resources = manifest
+            .project()
+            .external_resources()
+            .map(|path| canonical_path(PackPathRole::ExternalProjectResource, path))
+            .collect::<Result<BTreeSet<_>, _>>()?;
+
+        if let Some(path) = external_resources
+            .iter()
+            .find(|path| canonical_files.contains_key(path.as_str()))
+        {
+            return Err(PackInvariantError::PathRoleConflict {
+                path: path.to_string(),
+                first: PackPathRole::ProjectFile,
+                second: PackPathRole::ExternalProjectResource,
+            });
+        }
+
+        let mut project_paths = canonical_files
+            .keys()
+            .cloned()
+            .map(|path| (path, PackPathRole::ProjectFile))
+            .collect::<Vec<_>>();
+        project_paths.extend(
+            external_resources
+                .iter()
+                .cloned()
+                .map(|path| (path, PackPathRole::ExternalProjectResource)),
+        );
+        if let Some((ancestor, ancestor_role, descendant, descendant_role)) =
+            find_path_tree_conflict(project_paths)
+        {
+            return Err(PackInvariantError::PathTreeConflict {
+                ancestor: ancestor.to_string(),
+                ancestor_role,
+                descendant: descendant.to_string(),
+                descendant_role,
+                package: None,
+            });
+        }
+
+        if external_resources.contains(&entrypoint) {
+            return Err(PackInvariantError::EntrypointIsExternalResource(
+                entrypoint.to_string(),
+            ));
+        }
+        if !canonical_files.contains_key(&entrypoint) {
+            return Err(PackInvariantError::MissingEntrypoint(
+                entrypoint.to_string(),
+            ));
+        }
+
+        let vendored_packages = manifest
+            .vendored_packages()
+            .expect("accepted Pack Manifest contains valid package specifications")
+            .into_iter()
+            .map(|spec| spec.to_string())
+            .collect::<BTreeSet<_>>();
+        let external_packages = manifest
+            .unvendored_packages()
+            .expect("accepted Pack Manifest contains valid package specifications")
+            .into_iter()
+            .map(|spec| spec.to_string())
+            .collect::<BTreeSet<_>>();
+        if let Some(spec) = vendored_packages.intersection(&external_packages).next() {
+            return Err(PackInvariantError::PackageRoleConflict(spec.clone()));
+        }
+
+        let mut canonical_packages = BTreeMap::new();
+        for (_, package) in packages {
+            let key = package.spec.to_string();
+            if !vendored_packages.contains(&key) {
+                return Err(PackInvariantError::UndeclaredPackageData(key));
+            }
+            let package_files = package.files;
+            let paths = package_files
+                .keys()
+                .cloned()
+                .map(|path| (path, PackPathRole::PackageFile))
+                .collect();
+            if let Some((ancestor, ancestor_role, descendant, descendant_role)) =
+                find_path_tree_conflict(paths)
+            {
+                return Err(PackInvariantError::PathTreeConflict {
+                    ancestor: ancestor.to_string(),
+                    ancestor_role,
+                    descendant: descendant.to_string(),
+                    descendant_role,
+                    package: Some(key),
+                });
+            }
+            canonical_packages.insert(
+                key,
+                PackageFiles {
+                    spec: package.spec,
+                    files: package_files,
+                },
+            );
+        }
+        if let Some(spec) = vendored_packages
+            .iter()
+            .find(|spec| !canonical_packages.contains_key(*spec))
+        {
+            return Err(PackInvariantError::MissingVendoredPackageData(spec.clone()));
+        }
+
+        let canonical_font_data = font_data;
+        let mut canonical_fonts = Vec::new();
+        let mut font_faces = BTreeSet::new();
+        for entry in manifest.fonts() {
+            let path = canonical_path(PackPathRole::FontData, entry.path())?;
+            let conflicting_role = if path.as_str() == MANIFEST_PATH {
+                Some(PackPathRole::PackManifest)
+            } else if path.as_str().starts_with(PROJECT_PREFIX) {
+                Some(PackPathRole::ProjectFile)
+            } else if path.as_str().starts_with(PACKAGES_PREFIX) {
+                Some(PackPathRole::PackageFile)
+            } else {
+                None
+            };
+            if let Some(conflicting_role) = conflicting_role {
+                return Err(PackInvariantError::ReservedFontPath {
+                    path: path.to_string(),
+                    conflicting_role,
+                });
+            }
+            let index = entry.index();
+            if !font_faces.insert((path.clone(), index)) {
+                return Err(PackInvariantError::DuplicateFontFace {
+                    path: path.to_string(),
+                    index,
+                });
+            }
+            let data = canonical_font_data
+                .get(&path)
+                .cloned()
+                .ok_or_else(|| PackInvariantError::MissingFontData(path.to_string()))?;
+            let parsed =
+                Font::new(data.clone(), index).ok_or_else(|| PackInvariantError::InvalidFont {
+                    path: Some(path.to_string()),
+                    index,
+                })?;
+            canonical_fonts.push(PackFont {
+                entry: FontManifest::new(path.into_string(), index, entry.families().to_vec()),
+                data,
+                font: parsed,
+            });
+        }
+
+        let manifest = PackManifest::new(
+            entrypoint.into_string(),
+            external_resources
+                .into_iter()
+                .map(CanonicalPath::into_string)
+                .collect(),
+            vendored_packages.into_iter().collect(),
+            external_packages.into_iter().collect(),
+            canonical_fonts
+                .iter()
+                .map(|font| font.entry.clone())
+                .collect(),
+            manifest.metadata().cloned(),
+        );
+
+        Ok(Self {
+            manifest,
+            files: canonical_files,
+            packages: canonical_packages,
+            fonts: canonical_fonts,
+        })
+    }
+
     /// The pack manifest.
     pub fn manifest(&self) -> &PackManifest {
         &self.manifest
@@ -68,7 +293,7 @@ impl Pack {
 
     /// The root-relative path of the entrypoint file.
     pub fn entrypoint(&self) -> &str {
-        &self.manifest.project.entrypoint
+        self.manifest.project().entrypoint()
     }
 
     /// The project files, keyed by root-relative path.
@@ -83,15 +308,11 @@ impl Pack {
 
     /// The root-relative paths of resources supplied externally at compilation time.
     pub fn external_resources(&self) -> impl Iterator<Item = &str> {
-        self.manifest
-            .project
-            .external_resources
-            .iter()
-            .map(String::as_str)
+        self.manifest.project().external_resources()
     }
 
     pub(crate) fn is_external_resource(&self, path: &str) -> bool {
-        self.manifest.project.external_resources.contains(path)
+        self.manifest.project().contains_external_resource(path)
     }
 
     /// The vendored packages and their files.
@@ -126,108 +347,195 @@ impl Pack {
 
     /// Reads a pack from a seekable reader.
     pub fn read<R: Read + Seek>(reader: R) -> Result<Self, PackReadError> {
+        let archive = ZipArchive::new(reader)?;
+        let retained_entry_count = archive.len();
+        let central_directory_start = archive.central_directory_start();
+        let mut reader = archive.into_inner();
+        let raw_entries = raw_central_entries(&mut reader, central_directory_start)?;
+        let mut raw_names = BTreeSet::new();
+        for entry in &raw_entries {
+            if !raw_names.insert(entry.name.clone()) {
+                if entry.name == MANIFEST_PATH.as_bytes() {
+                    return Err(PackReadError::DuplicateManifest);
+                }
+                return Err(PackReadError::DuplicateArchiveEntry(entry.name.clone()));
+            }
+        }
+        if raw_entries.len() != retained_entry_count {
+            return Err(PackReadError::AmbiguousArchiveEntries);
+        }
         let mut archive = ZipArchive::new(reader)?;
 
-        let manifest = {
-            let mut entry = archive
-                .by_name(MANIFEST_PATH)
-                .map_err(|_| PackReadError::MissingManifest)?;
-            let mut text = String::new();
-            entry.read_to_string(&mut text)?;
-            PackManifest::from_toml(&text)?
-        };
+        struct ProjectEntry {
+            index: usize,
+            path: CanonicalPath,
+        }
+        struct PackageEntry {
+            index: usize,
+            spec: PackageSpec,
+            path: CanonicalPath,
+        }
+        struct UnknownEntry {
+            index: usize,
+            archive_name: String,
+            canonical_name: String,
+            regular_file: bool,
+        }
 
-        let mut files = BTreeMap::new();
-        let mut packages: BTreeMap<String, PackageFiles> = BTreeMap::new();
-        let mut fonts_by_path: BTreeMap<String, Bytes> = BTreeMap::new();
-        let font_paths: Vec<&str> = manifest
-            .fonts
-            .iter()
-            .map(|font| font.path.as_str())
-            .collect();
-
+        let mut manifest_entry = None;
+        let mut project_entries = Vec::new();
+        let mut package_entries = Vec::new();
+        let mut unknown_entries = Vec::new();
+        let mut canonical_archive_entries = BTreeMap::new();
         for index in 0..archive.len() {
-            let mut entry = archive.by_index(index)?;
+            let entry = archive.by_index_raw(index)?;
+            let archive_name = entry.name().to_owned();
+            let prefix_normalized_name = strip_current_directory_prefix(&archive_name);
+            if archive_name.is_empty()
+                || archive_name.starts_with('/')
+                || archive_name.starts_with('\\')
+                || archive_name.contains('\\')
+                || has_windows_drive_prefix(prefix_normalized_name)
+            {
+                return Err(PackReadError::UnsafeEntry(archive_name));
+            }
+            let enclosed_name = entry
+                .enclosed_name()
+                .ok_or_else(|| PackReadError::UnsafeEntry(archive_name.clone()))?;
+            let canonical_name = enclosed_name
+                .to_str()
+                .ok_or_else(|| PackReadError::UnsafeEntry(archive_name.clone()))?
+                .to_owned();
+            if has_windows_drive_prefix(&canonical_name) {
+                return Err(PackReadError::UnsafeEntry(archive_name));
+            }
+            register_archive_identity(
+                &mut canonical_archive_entries,
+                canonical_name.clone(),
+                &archive_name,
+            )?;
             if entry.is_dir() {
                 continue;
             }
-            let Some(name) = entry.enclosed_name() else {
-                return Err(PackReadError::UnsafeEntry(entry.name().to_owned()));
+            const FILE_TYPE_MASK: u32 = 0o170000;
+            const REGULAR_FILE: u32 = 0o100000;
+            let regular_file = entry.is_file()
+                && entry
+                    .unix_mode()
+                    .is_none_or(|mode| matches!(mode & FILE_TYPE_MASK, 0 | REGULAR_FILE));
+            let role_name = if prefix_normalized_name == MANIFEST_PATH
+                || prefix_normalized_name.starts_with(PROJECT_PREFIX)
+                || prefix_normalized_name.starts_with(PACKAGES_PREFIX)
+            {
+                prefix_normalized_name
+            } else {
+                canonical_name.as_str()
             };
-            let name = name.to_string_lossy().replace('\\', "/");
 
-            if name == MANIFEST_PATH {
-                continue;
-            } else if let Some(path) = name.strip_prefix(PROJECT_PREFIX) {
-                let path = normalize_path(path, &name)?;
-                let mut data = Vec::new();
-                entry.read_to_end(&mut data)?;
-                files.insert(path, Bytes::new(data));
-            } else if let Some(rest) = name.strip_prefix(PACKAGES_PREFIX) {
-                let (spec, path) = split_package_entry(rest, &name)?;
-                let key = spec.to_string();
-                if !manifest.packages.vendored.contains(&key) {
-                    return Err(PackReadError::UndeclaredPackage(key));
+            if role_name == MANIFEST_PATH {
+                register_archive_identity(
+                    &mut canonical_archive_entries,
+                    MANIFEST_PATH.to_owned(),
+                    &archive_name,
+                )?;
+                manifest_entry = Some((index, regular_file));
+            } else if let Some(path) = role_name.strip_prefix(PROJECT_PREFIX) {
+                if !regular_file {
+                    return Err(PackReadError::UnsupportedEntryType(archive_name));
                 }
-                let mut data = Vec::new();
-                entry.read_to_end(&mut data)?;
-                packages
-                    .entry(key)
-                    .or_insert_with(|| PackageFiles {
-                        spec,
-                        files: BTreeMap::new(),
-                    })
-                    .files
-                    .insert(path, Bytes::new(data));
-            } else if font_paths.contains(&name.as_str()) {
-                let mut data = Vec::new();
-                entry.read_to_end(&mut data)?;
-                fonts_by_path
-                    .entry(name)
-                    .or_insert_with(|| Bytes::new(data));
+                let path = canonical_path(PackPathRole::ProjectFile, path)?;
+                register_archive_identity(
+                    &mut canonical_archive_entries,
+                    format!("{PROJECT_PREFIX}{path}"),
+                    &archive_name,
+                )?;
+                project_entries.push(ProjectEntry { index, path });
+            } else if let Some(rest) = role_name.strip_prefix(PACKAGES_PREFIX) {
+                if !regular_file {
+                    return Err(PackReadError::UnsupportedEntryType(archive_name));
+                }
+                let (spec, path) = split_package_entry(rest, &archive_name)?;
+                register_archive_identity(
+                    &mut canonical_archive_entries,
+                    format!(
+                        "{PACKAGES_PREFIX}{}/{}/{}/{path}",
+                        spec.namespace, spec.name, spec.version
+                    ),
+                    &archive_name,
+                )?;
+                package_entries.push(PackageEntry { index, spec, path });
+            } else {
+                unknown_entries.push(UnknownEntry {
+                    index,
+                    archive_name,
+                    canonical_name,
+                    regular_file,
+                });
             }
-            // Unknown top-level entries are ignored for forward compatibility.
         }
 
-        if let Some(path) = manifest
-            .project
-            .external_resources
+        let (manifest_index, manifest_is_file) =
+            manifest_entry.ok_or(PackReadError::MissingManifest)?;
+        if !manifest_is_file {
+            return Err(PackReadError::ManifestNotFile);
+        }
+        let manifest = {
+            let mut entry = archive.by_index(manifest_index)?;
+            let mut bytes = Vec::new();
+            entry
+                .read_to_end(&mut bytes)
+                .map_err(PackReadError::ManifestUnreadable)?;
+            let text = std::str::from_utf8(&bytes).map_err(PackReadError::ManifestNotUtf8)?;
+            PackManifest::from_toml(text)?
+        };
+
+        let font_paths = manifest
+            .fonts()
             .iter()
-            .find(|path| files.contains_key(path.as_str()))
-        {
-            return Err(PackReadError::ExternalResourceConflict(path.clone()));
-        }
-
-        if !files.contains_key(&manifest.project.entrypoint) {
-            return Err(PackReadError::MissingEntrypoint(
-                manifest.project.entrypoint.clone(),
-            ));
-        }
-
-        for spec in manifest.vendored_packages()? {
-            if !packages.contains_key(&spec.to_string()) {
-                return Err(PackReadError::MissingPackage(spec.to_string()));
+            .filter_map(|font| canonical_path(PackPathRole::FontData, font.path()).ok())
+            .collect::<BTreeSet<_>>();
+        let mut font_entries = Vec::new();
+        for entry in unknown_entries {
+            if let Some(path) = font_paths.get(entry.canonical_name.as_str()) {
+                if !entry.regular_file {
+                    return Err(PackReadError::UnsupportedEntryType(entry.archive_name));
+                }
+                register_archive_identity(
+                    &mut canonical_archive_entries,
+                    path.to_string(),
+                    &entry.archive_name,
+                )?;
+                font_entries.push((entry.index, path.clone()));
             }
         }
 
-        let mut fonts = Vec::new();
-        for entry in &manifest.fonts {
-            let data = fonts_by_path
-                .get(&entry.path)
-                .cloned()
-                .ok_or_else(|| PackReadError::MissingFont(entry.path.clone()))?;
-            fonts.push(PackFont {
-                entry: entry.clone(),
-                data,
-            });
+        let mut files = BTreeMap::new();
+        for project in project_entries {
+            let mut data = Vec::new();
+            archive.by_index(project.index)?.read_to_end(&mut data)?;
+            files.insert(project.path, Bytes::new(data));
+        }
+        let mut packages: BTreeMap<String, PackageFiles> = BTreeMap::new();
+        for package in package_entries {
+            let mut data = Vec::new();
+            archive.by_index(package.index)?.read_to_end(&mut data)?;
+            packages
+                .entry(package.spec.to_string())
+                .or_insert_with(|| PackageFiles {
+                    spec: package.spec,
+                    files: BTreeMap::new(),
+                })
+                .files
+                .insert(package.path, Bytes::new(data));
+        }
+        let mut fonts_by_path = BTreeMap::new();
+        for (index, path) in font_entries {
+            let mut data = Vec::new();
+            archive.by_index(index)?.read_to_end(&mut data)?;
+            fonts_by_path.insert(path, Bytes::new(data));
         }
 
-        Ok(Self {
-            manifest,
-            files,
-            packages,
-            fonts,
-        })
+        Ok(Self::construct(manifest, files, packages, fonts_by_path)?)
     }
 
     /// Reads a pack from a byte buffer.
@@ -265,9 +573,9 @@ impl Pack {
 
         let mut written = std::collections::BTreeSet::new();
         for font in &self.fonts {
-            if written.insert(&font.entry.path) {
-                zip.start_file(&font.entry.path, options)?;
-                zip.write_all(&font.data)?;
+            if written.insert(font.manifest().path()) {
+                zip.start_file(font.manifest().path(), options)?;
+                zip.write_all(font.data())?;
             }
         }
 
@@ -283,19 +591,43 @@ impl Pack {
     }
 }
 
-/// Normalizes an archive path into a root-relative virtual path string.
-fn normalize_path(path: &str, entry: &str) -> Result<String, PackReadError> {
-    match VirtualPath::new(path) {
-        Ok(vpath) => Ok(vpath.get_without_slash().to_owned()),
-        Err(err) => Err(PackReadError::InvalidEntry {
-            entry: entry.to_owned(),
-            message: err.to_string(),
-        }),
+struct RawCentralEntry {
+    name: Vec<u8>,
+}
+
+fn raw_central_entries<R: Read + Seek>(
+    reader: &mut R,
+    central_directory_start: u64,
+) -> Result<Vec<RawCentralEntry>, PackReadError> {
+    reader.seek(SeekFrom::Start(central_directory_start))?;
+    let mut entries = Vec::new();
+    loop {
+        let header_start = reader.stream_position()?;
+        let mut signature = [0; 4];
+        reader.read_exact(&mut signature)?;
+        if signature != *b"PK\x01\x02" {
+            reader.seek(SeekFrom::Start(header_start))?;
+            break;
+        }
+
+        let mut fixed = [0; 42];
+        reader.read_exact(&mut fixed)?;
+        let name_len = u16::from_le_bytes([fixed[24], fixed[25]]) as usize;
+        let extra_len = u16::from_le_bytes([fixed[26], fixed[27]]) as i64;
+        let comment_len = u16::from_le_bytes([fixed[28], fixed[29]]) as i64;
+        let mut name = vec![0; name_len];
+        reader.read_exact(&mut name)?;
+        reader.seek(SeekFrom::Current(extra_len + comment_len))?;
+        entries.push(RawCentralEntry { name });
     }
+    Ok(entries)
 }
 
 /// Splits `namespace/name/version/rest...` into a package spec and file path.
-fn split_package_entry(rest: &str, entry: &str) -> Result<(PackageSpec, String), PackReadError> {
+fn split_package_entry(
+    rest: &str,
+    entry: &str,
+) -> Result<(PackageSpec, CanonicalPath), PackReadError> {
     let mut parts = rest.splitn(4, '/');
     let (Some(namespace), Some(name), Some(version), Some(path)) =
         (parts.next(), parts.next(), parts.next(), parts.next())
@@ -311,7 +643,7 @@ fn split_package_entry(rest: &str, entry: &str) -> Result<(PackageSpec, String),
             message: err.to_string(),
         }
     })?;
-    let path = normalize_path(path, entry)?;
+    let path = canonical_path(PackPathRole::PackageFile, path)?;
     Ok((spec, path))
 }
 
@@ -324,22 +656,28 @@ pub enum PackReadError {
     Io(#[from] std::io::Error),
     #[error("the archive contains no {MANIFEST_PATH} manifest (is this a Typst pack?)")]
     MissingManifest,
+    #[error("the archive contains more than one {MANIFEST_PATH} manifest")]
+    DuplicateManifest,
+    #[error("the archive contains a duplicate entry named {0:?}")]
+    DuplicateArchiveEntry(Vec<u8>),
+    #[error("the archive contains entries with ambiguous effective names")]
+    AmbiguousArchiveEntries,
+    #[error("the {MANIFEST_PATH} manifest is not a regular file")]
+    ManifestNotFile,
+    #[error("the {MANIFEST_PATH} manifest could not be read: {0}")]
+    ManifestUnreadable(#[source] std::io::Error),
+    #[error("the {MANIFEST_PATH} manifest is not valid UTF-8: {0}")]
+    ManifestNotUtf8(#[source] std::str::Utf8Error),
     #[error(transparent)]
     Manifest(#[from] PackManifestError),
     #[error("archive entry `{0}` has an unsafe path")]
     UnsafeEntry(String),
     #[error("invalid archive entry `{entry}`: {message}")]
     InvalidEntry { entry: String, message: String },
-    #[error("package `{0}` has files in the archive but is not declared in the manifest")]
-    UndeclaredPackage(String),
-    #[error("the manifest declares vendored package `{0}` but the archive has no files for it")]
-    MissingPackage(String),
-    #[error("entrypoint `{0}` is missing from the archive")]
-    MissingEntrypoint(String),
-    #[error("project path `{0}` cannot be both packed and an external project resource")]
-    ExternalResourceConflict(String),
-    #[error("font file `{0}` is declared in the manifest but missing from the archive")]
-    MissingFont(String),
+    #[error("archive entry `{0}` is not a regular file")]
+    UnsupportedEntryType(String),
+    #[error(transparent)]
+    Invariant(#[from] PackInvariantError),
 }
 
 /// A failure while writing a pack archive.
@@ -359,11 +697,11 @@ pub enum PackWriteError {
 #[derive(Debug)]
 pub struct PackBuilder {
     entrypoint: String,
-    files: BTreeMap<String, Bytes>,
-    external_resources: BTreeSet<String>,
+    files: BTreeMap<CanonicalPath, Bytes>,
+    external_resources: BTreeSet<CanonicalPath>,
     packages: BTreeMap<String, PackageFiles>,
     unvendored_packages: Vec<PackageSpec>,
-    fonts: Vec<PackFont>,
+    fonts: Vec<PackFontInput>,
     metadata: Option<PackMetadata>,
 }
 
@@ -387,15 +725,56 @@ impl PackBuilder {
         path: impl AsRef<str>,
         data: impl Into<Vec<u8>>,
     ) -> Result<Self, PackBuildError> {
-        let path = valid_path(path.as_ref())?;
+        let path = canonical_path(PackPathRole::ProjectFile, path.as_ref())?;
         self.files.insert(path, Bytes::new(data.into()));
         Ok(self)
     }
 
     /// Declares a non-source project resource whose bytes will be supplied externally.
     pub fn external_resource(mut self, path: impl AsRef<str>) -> Result<Self, PackBuildError> {
-        self.external_resources.insert(valid_path(path.as_ref())?);
+        self.external_resources.insert(canonical_path(
+            PackPathRole::ExternalProjectResource,
+            path.as_ref(),
+        )?);
         Ok(self)
+    }
+
+    #[cfg(feature = "fs")]
+    pub(crate) fn external_resource_paths(&self) -> BTreeSet<String> {
+        self.external_resources
+            .iter()
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    #[cfg(feature = "fs")]
+    pub(crate) fn validate_declarations(&self) -> Result<(), PackBuildError> {
+        let entrypoint = canonical_path(PackPathRole::Entrypoint, &self.entrypoint)?;
+        if self.external_resources.contains(&entrypoint) {
+            return Err(
+                PackInvariantError::EntrypointIsExternalResource(entrypoint.to_string()).into(),
+            );
+        }
+        let mut project_paths = vec![(entrypoint, PackPathRole::Entrypoint)];
+        project_paths.extend(
+            self.external_resources
+                .iter()
+                .cloned()
+                .map(|path| (path, PackPathRole::ExternalProjectResource)),
+        );
+        if let Some((ancestor, ancestor_role, descendant, descendant_role)) =
+            find_path_tree_conflict(project_paths)
+        {
+            return Err(PackInvariantError::PathTreeConflict {
+                ancestor: ancestor.to_string(),
+                ancestor_role,
+                descendant: descendant.to_string(),
+                descendant_role,
+                package: None,
+            }
+            .into());
+        }
+        Ok(())
     }
 
     /// Adds a file of a vendored package.
@@ -405,7 +784,7 @@ impl PackBuilder {
         path: impl AsRef<str>,
         data: impl Into<Vec<u8>>,
     ) -> Result<Self, PackBuildError> {
-        let path = valid_path(path.as_ref())?;
+        let path = canonical_path(PackPathRole::PackageFile, path.as_ref())?;
         self.packages
             .entry(spec.to_string())
             .or_insert_with(|| PackageFiles {
@@ -431,15 +810,12 @@ impl PackBuilder {
     /// entry name and family list are derived from the font data.
     pub fn font(mut self, data: impl Into<Vec<u8>>, index: u32) -> Result<Self, PackBuildError> {
         let data = data.into();
-        let info = FontInfo::new(&data, index).ok_or(PackBuildError::UnrecognizedFont)?;
+        let info = FontInfo::new(&data, index)
+            .ok_or(PackInvariantError::InvalidFont { path: None, index })?;
         let family = info.family.to_string();
         let path = self.font_path(&family, &data);
-        self.fonts.push(PackFont {
-            entry: FontManifest {
-                path,
-                index,
-                families: vec![family],
-            },
+        self.fonts.push(PackFontInput {
+            entry: FontManifest::new(path, index, vec![family]),
             data: Bytes::new(data),
         });
         Ok(self)
@@ -453,46 +829,45 @@ impl PackBuilder {
 
     /// Finishes the pack.
     pub fn build(self) -> Result<Pack, PackBuildError> {
-        let entrypoint = valid_path(&self.entrypoint)?;
-        if !self.files.contains_key(&entrypoint) {
-            return Err(PackBuildError::MissingEntrypoint(entrypoint));
-        }
-        if let Some(path) = self
-            .external_resources
+        let entrypoint = canonical_path(PackPathRole::Entrypoint, &self.entrypoint)?;
+        let font_data = self
+            .fonts
             .iter()
-            .find(|path| self.files.contains_key(path.as_str()))
-        {
-            return Err(PackBuildError::ExternalResourceConflict(path.clone()));
-        }
+            .map(|font| {
+                Ok((
+                    canonical_path(PackPathRole::FontData, font.entry.path())?,
+                    font.data.clone(),
+                ))
+            })
+            .collect::<Result<BTreeMap<_, _>, PackInvariantError>>()?;
+        let manifest = PackManifest::new(
+            entrypoint.into_string(),
+            self.external_resources
+                .into_iter()
+                .map(CanonicalPath::into_string)
+                .collect(),
+            self.packages.keys().cloned().collect(),
+            self.unvendored_packages
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
+            self.fonts.iter().map(|font| font.entry.clone()).collect(),
+            self.metadata,
+        );
 
-        let manifest = PackManifest {
-            format_version: FORMAT_VERSION,
-            project: ProjectManifest {
-                entrypoint,
-                external_resources: self.external_resources,
-            },
-            packages: PackagesManifest {
-                vendored: self.packages.keys().cloned().collect(),
-                unvendored: self
-                    .unvendored_packages
-                    .iter()
-                    .map(|spec| spec.to_string())
-                    .collect(),
-            },
-            fonts: self.fonts.iter().map(|font| font.entry.clone()).collect(),
-            metadata: self.metadata,
-        };
-
-        Ok(Pack {
+        Ok(Pack::construct(
             manifest,
-            files: self.files,
-            packages: self.packages,
-            fonts: self.fonts,
-        })
+            self.files,
+            self.packages,
+            font_data,
+        )?)
     }
 
     /// Picks a unique archive path for a font file.
     fn font_path(&self, family: &str, data: &[u8]) -> String {
+        if let Some(existing) = self.fonts.iter().find(|font| font.data.as_slice() == data) {
+            return existing.entry.path().to_owned();
+        }
         let extension = match data.get(..4) {
             Some(b"OTTO") => "otf",
             Some(b"ttcf") => "ttc",
@@ -506,12 +881,14 @@ impl PackBuilder {
         let stem = stem.trim_matches('-');
         let stem = if stem.is_empty() { "font" } else { stem };
 
-        // Reuse the path if the identical file is already embedded (e.g.
-        // several faces of one collection), otherwise disambiguate.
         let mut candidate = format!("fonts/{stem}.{extension}");
         let mut counter = 1;
         loop {
-            match self.fonts.iter().find(|font| font.entry.path == candidate) {
+            match self
+                .fonts
+                .iter()
+                .find(|font| font.entry.path() == candidate)
+            {
                 None => return candidate,
                 Some(existing) if existing.data.as_slice() == data => return candidate,
                 Some(_) => {
@@ -523,25 +900,184 @@ impl PackBuilder {
     }
 }
 
-pub(crate) fn valid_path(path: &str) -> Result<String, PackBuildError> {
-    match VirtualPath::new(path) {
-        Ok(vpath) => Ok(vpath.get_without_slash().to_owned()),
-        Err(err) => Err(PackBuildError::InvalidPath {
-            path: path.to_owned(),
-            message: err.to_string(),
-        }),
+fn canonical_path(role: PackPathRole, path: &str) -> Result<CanonicalPath, PackInvariantError> {
+    let invalid = |message: String| PackInvariantError::InvalidPath {
+        role,
+        path: path.to_owned(),
+        message,
+    };
+    if path.is_empty() || path.starts_with('/') || path.starts_with('\\') {
+        return Err(invalid("path must name a root-relative file".to_owned()));
     }
+    if path.contains('\\') {
+        return Err(invalid(
+            "backslashes are not portable path separators".to_owned(),
+        ));
+    }
+    if has_windows_drive_prefix(path) {
+        return Err(invalid(
+            "path must not contain a platform root prefix".to_owned(),
+        ));
+    }
+    let vpath = VirtualPath::new(path).map_err(|err| invalid(err.to_string()))?;
+    let canonical = vpath.get_without_slash();
+    if canonical.is_empty() {
+        return Err(invalid("path must name a file".to_owned()));
+    }
+    if has_windows_drive_prefix(canonical) {
+        return Err(invalid(
+            "path must not contain a platform root prefix".to_owned(),
+        ));
+    }
+    Ok(CanonicalPath(canonical.to_owned()))
+}
+
+fn has_windows_drive_prefix(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
+fn strip_current_directory_prefix(mut path: &str) -> &str {
+    while let Some(rest) = path.strip_prefix("./") {
+        path = rest;
+    }
+    path
+}
+
+fn find_path_tree_conflict(
+    mut paths: Vec<(CanonicalPath, PackPathRole)>,
+) -> Option<(CanonicalPath, PackPathRole, CanonicalPath, PackPathRole)> {
+    paths.sort_by(|(left, _), (right, _)| left.cmp(right));
+    for (ancestor, ancestor_role) in &paths {
+        let prefix = format!("{ancestor}/");
+        let candidate = paths.partition_point(|(path, _)| path.as_str() < prefix.as_str());
+        if let Some((descendant, descendant_role)) = paths.get(candidate)
+            && descendant.as_str().starts_with(&prefix)
+        {
+            return Some((
+                ancestor.clone(),
+                *ancestor_role,
+                descendant.clone(),
+                *descendant_role,
+            ));
+        }
+    }
+    None
+}
+
+fn register_archive_identity(
+    entries: &mut BTreeMap<String, String>,
+    canonical: String,
+    archive_name: &str,
+) -> Result<(), PackInvariantError> {
+    if let Some(first_entry) = entries.get(&canonical) {
+        if first_entry == archive_name {
+            return Ok(());
+        }
+        return Err(PackInvariantError::CanonicalArchiveEntryCollision {
+            canonical,
+            first_entry: first_entry.clone(),
+            second_entry: archive_name.to_owned(),
+        });
+    }
+    entries.insert(canonical, archive_name.to_owned());
+    Ok(())
 }
 
 /// A failure while building a pack in memory.
 #[derive(Debug, thiserror::Error)]
 pub enum PackBuildError {
-    #[error("invalid project path `{path}`: {message}")]
-    InvalidPath { path: String, message: String },
-    #[error("entrypoint `{0}` was not added as a file")]
+    #[error(transparent)]
+    Invariant(#[from] PackInvariantError),
+}
+
+/// A violation of the invariants shared by every [`Pack`] construction path.
+#[derive(Debug, Clone, Eq, PartialEq, thiserror::Error)]
+pub enum PackInvariantError {
+    /// A path cannot identify a canonical file for its declared role.
+    #[error("invalid {role} path `{path}`: {message}")]
+    InvalidPath {
+        role: PackPathRole,
+        path: String,
+        message: String,
+    },
+    /// Distinct archive entries identify one canonical contained file.
+    #[error("archive entries `{first_entry}` and `{second_entry}` both identify `{canonical}`")]
+    CanonicalArchiveEntryCollision {
+        canonical: String,
+        first_entry: String,
+        second_entry: String,
+    },
+    /// One canonical path was assigned two incompatible roles.
+    #[error("path `{path}` cannot be both {first} and {second}")]
+    PathRoleConflict {
+        path: String,
+        first: PackPathRole,
+        second: PackPathRole,
+    },
+    /// One file path is an ancestor of another file path in the same tree.
+    #[error(
+        "{ancestor_role} path `{ancestor}` conflicts with {descendant_role} descendant `{descendant}` (package: {package:?})"
+    )]
+    PathTreeConflict {
+        ancestor: String,
+        ancestor_role: PackPathRole,
+        descendant: String,
+        descendant_role: PackPathRole,
+        package: Option<String>,
+    },
+    /// The entrypoint was declared as a non-source External Project Resource.
+    #[error("entrypoint `{0}` cannot be an External Project Resource")]
+    EntrypointIsExternalResource(String),
+    /// A package was declared both vendored and externally resolved.
+    #[error("package `{0}` cannot be both vendored and unvendored")]
+    PackageRoleConflict(String),
+    /// Package bytes exist without a matching vendored declaration.
+    #[error("package `{0}` has contained data but is not declared vendored")]
+    UndeclaredPackageData(String),
+    /// A vendored package declaration has no contained bytes.
+    #[error("vendored package `{0}` has no contained data")]
+    MissingVendoredPackageData(String),
+    /// A font declaration uses an archive path reserved for another role.
+    #[error("font data path `{path}` conflicts with the {conflicting_role} archive role")]
+    ReservedFontPath {
+        path: String,
+        conflicting_role: PackPathRole,
+    },
+    /// A font declaration has no contained bytes.
+    #[error("font data `{0}` is missing")]
+    MissingFontData(String),
+    /// Contained font bytes do not contain the declared face.
+    #[error("font data {path:?} does not contain a valid face at index {index}")]
+    InvalidFont { path: Option<String>, index: u32 },
+    /// The same contained font face was declared more than once.
+    #[error("font `{path}` declares face index {index} more than once")]
+    DuplicateFontFace { path: String, index: u32 },
+    /// The declared entrypoint is not present among the packed project files.
+    #[error("entrypoint `{0}` is not a contained project file")]
     MissingEntrypoint(String),
-    #[error("project path `{0}` cannot be both packed and an external project resource")]
-    ExternalResourceConflict(String),
-    #[error("font data could not be parsed as a font")]
-    UnrecognizedFont,
+}
+
+/// The role a path plays in a Pack invariant.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum PackPathRole {
+    PackManifest,
+    Entrypoint,
+    ProjectFile,
+    ExternalProjectResource,
+    PackageFile,
+    FontData,
+}
+
+impl std::fmt::Display for PackPathRole {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::PackManifest => "Pack Manifest",
+            Self::Entrypoint => "entrypoint",
+            Self::ProjectFile => "project file",
+            Self::ExternalProjectResource => "External Project Resource",
+            Self::PackageFile => "package file",
+            Self::FontData => "font data",
+        })
+    }
 }

--- a/src/packer.rs
+++ b/src/packer.rs
@@ -349,6 +349,10 @@ impl Packer {
         // A typst.toml next to the entrypoint travels along: it carries
         // template/package metadata that tooling may want after extraction.
         if !report.files.iter().any(|path| path == "typst.toml")
+            && !report
+                .external_resources
+                .iter()
+                .any(|path| path == "typst.toml")
             && let Ok(data) = std::fs::read(root.join("typst.toml"))
         {
             report.files.push("typst.toml".to_owned());

--- a/src/packer.rs
+++ b/src/packer.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use ecow::EcoVec;
-use typst::diag::{FileError, FileResult, SourceDiagnostic, Warned};
+use typst::diag::{FileResult, SourceDiagnostic, Warned};
 use typst::foundations::{Bytes, Datetime, Dict, Duration};
 use typst::layout::{Frame, FrameItem};
 use typst::syntax::package::PackageSpec;
@@ -21,17 +21,18 @@ use typst_kit::files::{FileLoader, FileStore, FsRoot, SystemFiles};
 use typst_kit::fonts::FontStore;
 use typst_layout::PagedDocument;
 
+use crate::external_resource::{Discovery as ExternalResources, Reference};
 use crate::manifest::PackMetadata;
-use crate::pack::{Pack, PackBuildError, valid_path};
-use crate::world::{load_external_resource, system_packages};
+use crate::pack::{Pack, PackBuildError};
+use crate::world::system_packages;
 
-/// Controls whether discovery may fall back to External Project Resource loaders.
+/// Controls whether discovery may fall back to External Resource References.
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
 pub enum ProjectResourcePolicy {
-    /// Missing project files cannot fall back to external loaders.
+    /// Missing project files cannot fall back to External Resource References.
     #[default]
     DisallowExternalFallback,
-    /// Missing non-source resources may come from configured external loaders.
+    /// Missing non-source resources may come from configured External Resource References.
     AllowExternalFallback,
 }
 
@@ -40,8 +41,8 @@ pub enum ProjectResourcePolicy {
 /// The packer performs a discovery compile of the project and records every
 /// file Typst actually reads. Source-project files are packed by default.
 /// When [`AllowExternalFallback`](ProjectResourcePolicy::AllowExternalFallback)
-/// is selected, non-source resources resolved by configured external loaders
-/// are declared in the manifest instead of storing their bytes. Files that a
+/// is selected, non-source resources resolved by configured External Resource
+/// References are declared in the manifest instead of storing their bytes. Files that a
 /// compile with different inputs or a different date would read are not
 /// discovered; add packed files with [`include`](Self::include) or declare an
 /// External Project Resource with [`external_resource`](Self::external_resource).
@@ -61,7 +62,7 @@ pub struct Packer {
     metadata: Option<PackMetadata>,
     project_resource_policy: ProjectResourcePolicy,
     external_resources: BTreeSet<String>,
-    external_resource_loaders: Vec<Box<dyn FileLoader + Send + Sync>>,
+    external_resource_references: Vec<Reference>,
 }
 
 impl Packer {
@@ -84,7 +85,7 @@ impl Packer {
             metadata: None,
             project_resource_policy: ProjectResourcePolicy::default(),
             external_resources: BTreeSet::new(),
-            external_resource_loaders: Vec::new(),
+            external_resource_references: Vec::new(),
         }
     }
 
@@ -171,7 +172,7 @@ impl Packer {
         self
     }
 
-    /// Controls whether discovery may use configured External Project Resource loaders.
+    /// Controls whether discovery may use configured External Resource References.
     pub fn project_resource_policy(mut self, policy: ProjectResourcePolicy) -> Self {
         self.project_resource_policy = policy;
         self
@@ -183,26 +184,21 @@ impl Packer {
         self
     }
 
-    /// Adds a loader for External Project Resources used during discovery.
+    /// Adds an External Resource Reference used during discovery.
     ///
-    /// Loaders are only consulted under
+    /// References are only consulted under
     /// [`AllowExternalFallback`](ProjectResourcePolicy::AllowExternalFallback);
     /// registering one does not change the default strict policy.
-    pub fn external_resource_loader(
+    pub fn external_resource_reference(
         mut self,
-        loader: impl FileLoader + Send + Sync + 'static,
+        reference: impl FileLoader + Send + Sync + 'static,
     ) -> Self {
-        self.external_resource_loaders.push(Box::new(loader));
+        self.external_resource_references.push(Box::new(reference));
         self
     }
 
     /// Runs the discovery compile and assembles the pack.
     pub fn pack(self) -> Result<PackOutcome, PackerError> {
-        let explicit_external_resources = self
-            .external_resources
-            .iter()
-            .map(|path| valid_path(path))
-            .collect::<Result<BTreeSet<_>, _>>()?;
         let root = self
             .root
             .canonicalize()
@@ -217,6 +213,12 @@ impl Packer {
             .map_err(|err| PackerError::io("failed to resolve entrypoint", err))?;
         let entrypoint = VirtualPath::virtualize(&root, &entrypoint_abs)
             .map_err(|_| PackerError::OutsideRoot(entrypoint_abs.clone()))?;
+        let mut builder = Pack::builder(entrypoint.get_without_slash());
+        for path in &self.external_resources {
+            builder = builder.external_resource(path)?;
+        }
+        builder.validate_declarations()?;
+        let explicit_external_resources = builder.external_resource_paths();
 
         // Build the discovery world.
         let packages = system_packages(
@@ -246,10 +248,11 @@ impl Packer {
             sources: FileStore::new(Arc::clone(&primary)),
             files: FileStore::new(DiscoveryLoader {
                 primary,
-                policy: self.project_resource_policy,
-                external_loaders: self.external_resource_loaders,
-                external_resources: Mutex::new(explicit_external_resources.clone()),
-                explicit_external_resources,
+                external_resources: ExternalResources::new(
+                    self.external_resource_references,
+                    self.project_resource_policy == ProjectResourcePolicy::AllowExternalFallback,
+                    explicit_external_resources,
+                ),
             }),
             fonts,
             time: Time::system(),
@@ -317,8 +320,6 @@ impl Packer {
                 }
             }
         }
-
-        let mut builder = Pack::builder(entrypoint.get_without_slash());
 
         for path in world.files.loader().external_resources() {
             report.external_resources.push(path.clone());
@@ -457,7 +458,7 @@ impl Packer {
         report.fonts = pack
             .fonts()
             .iter()
-            .map(|font| font.entry.path.clone())
+            .map(|font| font.manifest().path().to_owned())
             .collect();
 
         Ok(PackOutcome {
@@ -586,17 +587,13 @@ impl World for DiscoveryWorld {
     }
 
     fn source(&self, id: FileId) -> FileResult<Source> {
-        if matches!(id.root(), VirtualRoot::Project) && self.files.loader().is_explicit_external(id)
-        {
-            return Err(FileError::NotFound(PathBuf::from(
-                id.vpath().get_without_slash(),
-            )));
-        }
-        #[cfg(test)]
-        if let Some(hook) = &self.source_request_hook {
-            hook(id);
-        }
-        self.sources.source(id)
+        self.files.loader().external_resources.source(id, || {
+            #[cfg(test)]
+            if let Some(hook) = &self.source_request_hook {
+                hook(id);
+            }
+            self.sources.source(id)
+        })
     }
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {
@@ -635,10 +632,7 @@ impl FileLoader for PrimaryLoader {
 
 struct DiscoveryLoader {
     primary: Arc<PrimaryLoader>,
-    policy: ProjectResourcePolicy,
-    external_loaders: Vec<Box<dyn FileLoader + Send + Sync>>,
-    external_resources: Mutex<BTreeSet<String>>,
-    explicit_external_resources: BTreeSet<String>,
+    external_resources: ExternalResources,
 }
 
 impl DiscoveryLoader {
@@ -647,56 +641,17 @@ impl DiscoveryLoader {
     }
 
     fn is_external(&self, id: FileId) -> bool {
-        self.external_resources
-            .lock()
-            .expect("external resource provenance lock poisoned")
-            .contains(id.vpath().get_without_slash())
-    }
-
-    fn is_explicit_external(&self, id: FileId) -> bool {
-        self.explicit_external_resources
-            .contains(id.vpath().get_without_slash())
+        self.external_resources.is_external(id)
     }
 
     fn external_resources(&self) -> Vec<String> {
-        self.external_resources
-            .lock()
-            .expect("external resource provenance lock poisoned")
-            .iter()
-            .cloned()
-            .collect()
+        self.external_resources.external_resources()
     }
 }
 
 impl FileLoader for DiscoveryLoader {
     fn load(&self, id: FileId) -> FileResult<Bytes> {
-        match self.primary.load(id) {
-            Ok(data) => {
-                if matches!(id.root(), VirtualRoot::Project)
-                    && self
-                        .explicit_external_resources
-                        .contains(id.vpath().get_without_slash())
-                {
-                    self.external_resources
-                        .lock()
-                        .expect("external resource provenance lock poisoned")
-                        .insert(id.vpath().get_without_slash().to_owned());
-                }
-                Ok(data)
-            }
-            Err(FileError::NotFound(_))
-                if matches!(id.root(), VirtualRoot::Project)
-                    && self.policy == ProjectResourcePolicy::AllowExternalFallback =>
-            {
-                let data = load_external_resource(&self.external_loaders, id)?;
-                self.external_resources
-                    .lock()
-                    .expect("external resource provenance lock poisoned")
-                    .insert(id.vpath().get_without_slash().to_owned());
-                Ok(data)
-            }
-            Err(err) => Err(err),
-        }
+        self.external_resources.file(id, || self.primary.load(id))
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -436,6 +436,20 @@ fn pack_builder_rejects_paths_that_cannot_name_root_relative_files() {
             }))
         ));
     }
+    assert!(matches!(
+        Pack::builder("main\0.typ").build(),
+        Err(PackBuildError::Invariant(PackInvariantError::InvalidPath {
+            role: PackPathRole::Entrypoint,
+            ..
+        }))
+    ));
+    assert!(matches!(
+        Pack::builder("main.typ").file("main\0.typ", Vec::new()),
+        Err(PackBuildError::Invariant(PackInvariantError::InvalidPath {
+            role: PackPathRole::ProjectFile,
+            ..
+        }))
+    ));
 }
 
 #[test]
@@ -587,12 +601,10 @@ fn pack_construction_rejects_invalid_contained_font_data() {
 }
 
 #[test]
-fn pack_builder_reports_invalid_font_data_as_a_shared_invariant() {
+fn pack_builder_reports_invalid_font_data_as_an_ingestion_error() {
     assert!(matches!(
         Pack::builder("main.typ").font(b"not a font".to_vec(), 2),
-        Err(PackBuildError::Invariant(
-            PackInvariantError::InvalidFontInput { index: 2 }
-        ))
+        Err(PackBuildError::InvalidFontInput { index: 2 })
     ));
 }
 
@@ -653,6 +665,20 @@ fn pack_construction_rejects_font_paths_reserved_for_project_files() {
             ref path,
             conflicting_role: PackPathRole::ProjectFile,
         })) if path == "project/main.typ"
+    ));
+}
+
+#[test]
+fn pack_construction_rejects_font_path_at_the_manifest() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[[fonts]]\npath = \"typst-pack.toml\"\nfamilies = [\"Informational\"]\n";
+    let bytes = raw_stored_zip(&[(MANIFEST_PATH, manifest), ("project/main.typ", b"Hello")]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::Invariant(PackInvariantError::ReservedFontPath {
+            ref path,
+            conflicting_role: PackPathRole::PackManifest,
+        })) if path == MANIFEST_PATH
     ));
 }
 
@@ -730,7 +756,7 @@ fn invariant_diagnostics_do_not_expose_optional_field_formatting() {
         "project file path `assets` conflicts with External Project Resource descendant `assets/logo.png`"
     );
 
-    let font = PackInvariantError::InvalidFontInput { index: 2 };
+    let font = PackBuildError::InvalidFontInput { index: 2 };
     assert_eq!(
         font.to_string(),
         "font input does not contain a valid face at index 2"
@@ -792,6 +818,45 @@ fn pack_roundtrip_in_memory() {
         reread.file("note.typ").unwrap().as_slice(),
         "Hello".as_bytes()
     );
+}
+
+#[cfg(feature = "embedded-fonts")]
+#[test]
+fn full_unicode_pack_roundtrip_is_equivalent_and_idempotent() {
+    let vendored = "@local/example:1.0.0"
+        .parse::<typst::syntax::package::PackageSpec>()
+        .unwrap();
+    let unvendored = "@local/remote:2.0.0"
+        .parse::<typst::syntax::package::PackageSpec>()
+        .unwrap();
+    let pack = Pack::builder("文档.typ")
+        .file("文档.typ", b"Hello".to_vec())
+        .unwrap()
+        .file("资料/说明.txt", b"Notes".to_vec())
+        .unwrap()
+        .external_resource("品牌/图.png")
+        .unwrap()
+        .package_file(vendored, "章节.typ", b"Package".to_vec())
+        .unwrap()
+        .unvendored_package(unvendored)
+        .font(embedded_font_data(), 0)
+        .unwrap()
+        .metadata(PackMetadata::new().with_name("完整 Pack"))
+        .build()
+        .unwrap();
+
+    let bytes = pack.to_bytes().unwrap();
+    let reread = Pack::from_bytes(bytes.clone()).unwrap();
+
+    assert_eq!(reread.manifest(), pack.manifest());
+    assert_eq!(reread.file("资料/说明.txt").unwrap().as_slice(), b"Notes");
+    assert_eq!(
+        reread.external_resources().collect::<Vec<_>>(),
+        ["品牌/图.png"]
+    );
+    assert_eq!(reread.packages().count(), 1);
+    assert_eq!(reread.fonts().len(), 1);
+    assert_eq!(reread.to_bytes().unwrap(), bytes);
 }
 
 #[test]
@@ -857,12 +922,42 @@ fn read_rejects_archives_without_manifest() {
 }
 
 #[test]
+fn read_accepts_a_manifest_that_is_not_the_first_entry() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    let pack = Pack::from_bytes(raw_stored_zip(&[
+        ("project/main.typ", b"Hello"),
+        (MANIFEST_PATH, manifest),
+    ]))
+    .unwrap();
+
+    assert_eq!(pack.file("main.typ").unwrap().as_slice(), b"Hello");
+}
+
+#[test]
 fn read_reports_a_non_utf8_manifest_specifically() {
     let bytes = raw_stored_zip(&[(MANIFEST_PATH, &[0xff]), ("project/main.typ", b"Hello")]);
 
     assert!(matches!(
         Pack::from_bytes(bytes),
         Err(PackReadError::ManifestNotUtf8(_))
+    ));
+}
+
+#[test]
+fn manifest_decoding_failures_precede_archive_path_failures() {
+    let non_utf8 = raw_stored_zip(&[(MANIFEST_PATH, &[0xff]), ("project/../bad.typ", b"bad")]);
+    assert!(matches!(
+        Pack::from_bytes(non_utf8),
+        Err(PackReadError::ManifestNotUtf8(_))
+    ));
+
+    let malformed = raw_stored_zip(&[
+        (MANIFEST_PATH, b"not valid TOML = ["),
+        ("project/../bad.typ", b"bad"),
+    ]);
+    assert!(matches!(
+        Pack::from_bytes(malformed),
+        Err(PackReadError::Manifest(_))
     ));
 }
 
@@ -944,6 +1039,22 @@ fn read_rejects_duplicate_manifest_entries() {
     assert!(matches!(
         Pack::from_bytes(bytes),
         Err(PackReadError::DuplicateManifest)
+    ));
+}
+
+#[test]
+fn read_rejects_exact_duplicate_unknown_entries() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    let bytes = raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+        ("future/data", b"first"),
+        ("future/data", b"second"),
+    ]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::DuplicateArchiveEntry(ref name)) if name == b"future/data"
     ));
 }
 
@@ -1597,6 +1708,24 @@ Rows: #csv("data.csv").len()
     }
 
     #[test]
+    fn package_discovery_does_not_consult_external_resource_providers() {
+        let dir = tempfile::tempdir().unwrap();
+        let (project, packages) = fixture(dir.path());
+        let (provider, calls) = MemoryProjectFile::tracked("lib.typ", b"injected".to_vec());
+
+        let outcome = Packer::new(&project, "main.typ")
+            .package_path(&packages)
+            .system_fonts(false)
+            .project_resource_policy(ProjectResourcePolicy::AllowExternalFallback)
+            .external_resource_reference(provider)
+            .pack()
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
+        assert_eq!(outcome.report.packages_vendored.len(), 1);
+    }
+
+    #[test]
     fn package_data_precedes_package_cache_during_discovery() {
         let dir = tempfile::tempdir().unwrap();
         let project = dir.path().join("project");
@@ -1838,6 +1967,29 @@ Rows: #csv("data.csv").len()
                     second: PackPathRole::ExternalProjectResource,
                 }
             ))) if path == "main.typ"
+        ));
+    }
+
+    #[test]
+    fn invalid_explicit_resource_slot_fails_before_discovery() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        fs::write(project.join("main.typ"), "#panic(\"discovery ran\")").unwrap();
+
+        let result = Packer::new(&project, "main.typ")
+            .system_fonts(false)
+            .external_resource("../outside.bin")
+            .pack();
+
+        assert!(matches!(
+            result,
+            Err(PackerError::Build(PackBuildError::Invariant(
+                PackInvariantError::InvalidPath {
+                    role: PackPathRole::ExternalProjectResource,
+                    ..
+                }
+            )))
         ));
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -232,6 +232,13 @@ fn with_first_zip_entry_unix_mode(mut archive: Vec<u8>, mode: u32) -> Vec<u8> {
     archive
 }
 
+fn with_first_zip_entry_corrupt_data(mut archive: Vec<u8>) -> Vec<u8> {
+    let name_len = u16::from_le_bytes(archive[26..28].try_into().unwrap()) as usize;
+    let extra_len = u16::from_le_bytes(archive[28..30].try_into().unwrap()) as usize;
+    archive[30 + name_len + extra_len] ^= 1;
+    archive
+}
+
 #[test]
 fn manifest_roundtrip() {
     let manifest = PackManifest::from_toml(
@@ -568,6 +575,110 @@ fn pack_construction_rejects_package_declaration_data_disagreement() {
         Err(PackReadError::Invariant(
             PackInvariantError::UndeclaredPackageData(ref spec)
         )) if spec == "@local/example:1.0.0"
+    ));
+}
+
+#[test]
+fn pack_construction_rejects_package_specs_that_do_not_roundtrip() {
+    let mut invalid = "@local/example:1.0.0"
+        .parse::<typst::syntax::package::PackageSpec>()
+        .unwrap();
+    invalid.name = "bad/name".into();
+
+    let vendored = Pack::builder("main.typ")
+        .file("main.typ", b"Hello".to_vec())
+        .unwrap()
+        .package_file(invalid.clone(), "lib.typ", b"Hello".to_vec())
+        .unwrap()
+        .build();
+    let unvendored = Pack::builder("main.typ")
+        .file("main.typ", b"Hello".to_vec())
+        .unwrap()
+        .unvendored_package(invalid)
+        .build();
+
+    assert!(matches!(
+        vendored,
+        Err(PackBuildError::Invariant(
+            PackInvariantError::InvalidPackageSpec { .. }
+        ))
+    ));
+    assert!(matches!(
+        unvendored,
+        Err(PackBuildError::Invariant(
+            PackInvariantError::InvalidPackageSpec { .. }
+        ))
+    ));
+}
+
+#[test]
+fn pack_construction_rejects_archive_entry_names_too_long_for_zip() {
+    let maximum_path = "a".repeat(65_535 - "project/".len());
+    let pack = Pack::builder(&maximum_path)
+        .file(&maximum_path, b"Hello".to_vec())
+        .unwrap()
+        .build()
+        .unwrap();
+    assert!(pack.to_bytes().is_ok());
+
+    let path = format!("{maximum_path}a");
+    let project = Pack::builder(&path)
+        .file(&path, b"Hello".to_vec())
+        .unwrap()
+        .build();
+    assert!(matches!(
+        project,
+        Err(PackBuildError::Invariant(
+            PackInvariantError::ArchiveEntryNameTooLong {
+                role: PackPathRole::ProjectFile,
+                ..
+            }
+        ))
+    ));
+
+    let spec = "@local/example:1.0.0"
+        .parse::<typst::syntax::package::PackageSpec>()
+        .unwrap();
+    let package_path = "a".repeat(65_535);
+    let package = Pack::builder("main.typ")
+        .file("main.typ", b"Hello".to_vec())
+        .unwrap()
+        .package_file(spec, package_path, b"Package".to_vec())
+        .unwrap()
+        .build();
+    assert!(matches!(
+        package,
+        Err(PackBuildError::Invariant(
+            PackInvariantError::ArchiveEntryNameTooLong {
+                role: PackPathRole::PackageFile,
+                ..
+            }
+        ))
+    ));
+}
+
+#[test]
+fn archive_path_failures_precede_package_role_failures() {
+    let path = "a".repeat(65_535 - "project/".len() + 1);
+    let spec = "@local/example:1.0.0"
+        .parse::<typst::syntax::package::PackageSpec>()
+        .unwrap();
+    let pack = Pack::builder(&path)
+        .file(&path, b"Hello".to_vec())
+        .unwrap()
+        .package_file(spec.clone(), "lib.typ", b"Package".to_vec())
+        .unwrap()
+        .unvendored_package(spec)
+        .build();
+
+    assert!(matches!(
+        pack,
+        Err(PackBuildError::Invariant(
+            PackInvariantError::ArchiveEntryNameTooLong {
+                role: PackPathRole::ProjectFile,
+                ..
+            }
+        ))
     ));
 }
 
@@ -1045,6 +1156,20 @@ fn read_reports_a_non_utf8_manifest_specifically() {
 }
 
 #[test]
+fn read_reports_an_unreadable_manifest_payload_specifically() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    let bytes = with_first_zip_entry_corrupt_data(raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+    ]));
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::ManifestUnreadable(_))
+    ));
+}
+
+#[test]
 fn manifest_decoding_failures_precede_archive_path_failures() {
     let non_utf8 = raw_stored_zip(&[(MANIFEST_PATH, &[0xff]), ("project/../bad.typ", b"bad")]);
     assert!(matches!(
@@ -1059,6 +1184,39 @@ fn manifest_decoding_failures_precede_archive_path_failures() {
     assert!(matches!(
         Pack::from_bytes(malformed),
         Err(PackReadError::Manifest(_))
+    ));
+
+    let duplicate_with_non_utf8_manifest = raw_stored_zip(&[
+        (MANIFEST_PATH, &[0xff]),
+        ("future/data", b"first"),
+        ("future/data", b"second"),
+    ]);
+    assert!(matches!(
+        Pack::from_bytes(duplicate_with_non_utf8_manifest),
+        Err(PackReadError::ManifestNotUtf8(_))
+    ));
+
+    let duplicate_with_malformed_manifest = raw_stored_zip(&[
+        (MANIFEST_PATH, b"not valid TOML = ["),
+        ("future/data", b"first"),
+        ("future/data", b"second"),
+    ]);
+    assert!(matches!(
+        Pack::from_bytes(duplicate_with_malformed_manifest),
+        Err(PackReadError::Manifest(_))
+    ));
+
+    let duplicate_with_unsupported_manifest = raw_stored_zip(&[
+        (
+            MANIFEST_PATH,
+            b"format-version = 99\n[project]\nentrypoint = \"main.typ\"\n",
+        ),
+        ("future/data", b"first"),
+        ("future/data", b"second"),
+    ]);
+    assert!(matches!(
+        Pack::from_bytes(duplicate_with_unsupported_manifest),
+        Err(PackReadError::DuplicateArchiveEntry(ref name)) if name == b"future/data"
     ));
 }
 
@@ -1325,6 +1483,54 @@ fn read_classifies_safe_archive_prefix_aliases_by_their_canonical_role() {
 }
 
 #[test]
+fn read_accepts_safe_aliases_at_archive_role_boundaries() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    let project = Pack::from_bytes(raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project//main.typ", b"Hello"),
+    ]))
+    .unwrap();
+    assert_eq!(project.file("main.typ").unwrap().as_slice(), b"Hello");
+
+    let package_manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[packages]\nvendored = [\"@local/example:1.0.0\"]\n";
+    let package = Pack::from_bytes(raw_stored_zip(&[
+        (MANIFEST_PATH, package_manifest),
+        ("project/main.typ", b"Hello"),
+        ("packages/local/example/1.0.0//lib.typ", b"Package"),
+    ]))
+    .unwrap();
+    let spec = "@local/example:1.0.0"
+        .parse::<typst::syntax::package::PackageSpec>()
+        .unwrap();
+    assert_eq!(
+        package.package_file(&spec, "lib.typ").unwrap().as_slice(),
+        b"Package"
+    );
+
+    let aliased_manifest = Pack::from_bytes(raw_stored_zip(&[
+        ("alias/../typst-pack.toml", manifest),
+        ("project/main.typ", b"Hello"),
+    ]))
+    .unwrap();
+    assert_eq!(
+        aliased_manifest.file("main.typ").unwrap().as_slice(),
+        b"Hello"
+    );
+
+    let colliding_manifest = raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("alias/../typst-pack.toml", manifest),
+        ("project/main.typ", b"Hello"),
+    ]);
+    assert!(matches!(
+        Pack::from_bytes(colliding_manifest),
+        Err(PackReadError::Invariant(
+            PackInvariantError::CanonicalArchiveEntryCollision { ref canonical, .. }
+        )) if canonical == MANIFEST_PATH
+    ));
+}
+
+#[test]
 fn read_rejects_external_project_resource_file_conflicts() {
     use std::io::Write;
 
@@ -1570,12 +1776,23 @@ fn external_resource_references_follow_registration_order() {
 
     let (denied, denied_calls) = ErrorProjectLoader::tracked(FileError::AccessDenied);
     let (masked, masked_calls) = MemoryProjectFile::tracked("resource.bin", b"masked".to_vec());
-    let world = PackWorld::builder(pack)
+    let world = PackWorld::builder(pack.clone())
         .external_resource_reference(denied)
         .external_resource_reference(masked)
         .build();
     assert_eq!(world.file(id), Err(FileError::AccessDenied));
     assert_eq!(denied_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(masked_calls.load(Ordering::Relaxed), 0);
+
+    let integrity_error = FileError::Other(Some("checksum mismatch".into()));
+    let (corrupt, corrupt_calls) = ErrorProjectLoader::tracked(integrity_error.clone());
+    let (masked, masked_calls) = MemoryProjectFile::tracked("resource.bin", b"masked".to_vec());
+    let world = PackWorld::builder(pack)
+        .external_resource_reference(corrupt)
+        .external_resource_reference(masked)
+        .build();
+    assert_eq!(world.file(id), Err(integrity_error));
+    assert_eq!(corrupt_calls.load(Ordering::Relaxed), 1);
     assert_eq!(masked_calls.load(Ordering::Relaxed), 0);
 }
 
@@ -2285,6 +2502,59 @@ Rows: #csv("data.csv").len()
         assert_eq!(fallback_calls.load(Ordering::Relaxed), 1);
         assert_eq!(outcome.report.external_resources, ["resource.bin"]);
         assert!(outcome.pack.file("resource.bin").is_none());
+    }
+
+    #[test]
+    fn discovery_all_missing_providers_report_the_requested_project_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        fs::write(project.join("main.typ"), "#read(\"requested.bin\")").unwrap();
+
+        let (provider, calls) = ErrorProjectLoader::tracked(FileError::NotFound(PathBuf::from(
+            "/host-specific/missing.bin",
+        )));
+        let result = Packer::new(&project, "main.typ")
+            .system_fonts(false)
+            .project_resource_policy(ProjectResourcePolicy::AllowExternalFallback)
+            .external_resource_reference(provider)
+            .pack();
+        let Err(PackerError::Compile { world, .. }) = result else {
+            panic!("missing provider unexpectedly satisfied discovery")
+        };
+
+        assert_eq!(
+            world.file(project_file_id("requested.bin")),
+            Err(FileError::NotFound(PathBuf::from("requested.bin")))
+        );
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn discovery_propagates_provider_errors_without_falling_through() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        fs::write(project.join("main.typ"), "#read(\"resource.bin\")").unwrap();
+
+        let (denied, denied_calls) = ErrorProjectLoader::tracked(FileError::AccessDenied);
+        let (masked, masked_calls) = MemoryProjectFile::tracked("resource.bin", b"masked".to_vec());
+        let result = Packer::new(&project, "main.typ")
+            .system_fonts(false)
+            .project_resource_policy(ProjectResourcePolicy::AllowExternalFallback)
+            .external_resource_reference(denied)
+            .external_resource_reference(masked)
+            .pack();
+        let Err(PackerError::Compile { world, .. }) = result else {
+            panic!("provider error was unexpectedly masked")
+        };
+
+        assert_eq!(
+            world.file(project_file_id("resource.bin")),
+            Err(FileError::AccessDenied)
+        );
+        assert_eq!(denied_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(masked_calls.load(Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -102,6 +102,14 @@ fn project_file_id(path: &str) -> FileId {
 }
 
 fn raw_stored_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let entries = entries
+        .iter()
+        .map(|(name, data)| (name.as_bytes(), false, *data))
+        .collect::<Vec<_>>();
+    raw_stored_zip_with_raw_names(&entries)
+}
+
+fn raw_stored_zip_with_raw_names(entries: &[(&[u8], bool, &[u8])]) -> Vec<u8> {
     fn crc32(data: &[u8]) -> u32 {
         let mut crc = !0u32;
         for byte in data {
@@ -123,12 +131,13 @@ fn raw_stored_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
 
     let mut archive = Vec::new();
     let mut central_entries = Vec::new();
-    for (name, data) in entries {
+    for &(name, utf8, data) in entries {
         let offset = archive.len();
         let crc = crc32(data);
+        let flags: u16 = if utf8 { 1 << 11 } else { 0 };
         archive.extend_from_slice(b"PK\x03\x04");
         archive.extend_from_slice(&20u16.to_le_bytes());
-        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(&flags.to_le_bytes());
         archive.extend_from_slice(&0u16.to_le_bytes());
         archive.extend_from_slice(&0u16.to_le_bytes());
         archive.extend_from_slice(&0u16.to_le_bytes());
@@ -137,17 +146,17 @@ fn raw_stored_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
         archive.extend_from_slice(&u32_bytes(data.len()));
         archive.extend_from_slice(&u16_bytes(name.len()));
         archive.extend_from_slice(&0u16.to_le_bytes());
-        archive.extend_from_slice(name.as_bytes());
+        archive.extend_from_slice(name);
         archive.extend_from_slice(data);
-        central_entries.push((name, data.len(), crc, offset));
+        central_entries.push((name, flags, data.len(), crc, offset));
     }
 
     let central_start = archive.len();
-    for (name, size, crc, offset) in central_entries {
+    for (name, flags, size, crc, offset) in central_entries {
         archive.extend_from_slice(b"PK\x01\x02");
         archive.extend_from_slice(&20u16.to_le_bytes());
         archive.extend_from_slice(&20u16.to_le_bytes());
-        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(&flags.to_le_bytes());
         archive.extend_from_slice(&0u16.to_le_bytes());
         archive.extend_from_slice(&0u16.to_le_bytes());
         archive.extend_from_slice(&0u16.to_le_bytes());
@@ -161,7 +170,7 @@ fn raw_stored_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
         archive.extend_from_slice(&0u16.to_le_bytes());
         archive.extend_from_slice(&0u32.to_le_bytes());
         archive.extend_from_slice(&u32_bytes(offset));
-        archive.extend_from_slice(name.as_bytes());
+        archive.extend_from_slice(name);
     }
     let central_size = archive.len() - central_start;
     archive.extend_from_slice(b"PK\x05\x06");
@@ -208,8 +217,8 @@ fn manifest_roundtrip() {
     )
     .unwrap();
     assert_eq!(manifest.project().entrypoint(), "main.typ");
-    assert_eq!(manifest.vendored_packages().unwrap().len(), 1);
-    assert_eq!(manifest.unvendored_packages().unwrap().len(), 1);
+    assert_eq!(manifest.vendored_packages().len(), 1);
+    assert_eq!(manifest.unvendored_packages().len(), 1);
 
     let serialized = manifest.to_toml();
     assert!(serialized.contains("external ="));
@@ -250,8 +259,14 @@ fn manifest_declarations_are_exposed_read_only_through_accessors() {
         manifest.project().external_resources().collect::<Vec<_>>(),
         ["logo.png"]
     );
-    assert_eq!(manifest.packages().vendored(), ["@preview/cetz:0.3.4"]);
-    assert_eq!(manifest.packages().unvendored(), ["@preview/tablex:0.0.9"]);
+    let vendored = "@preview/cetz:0.3.4"
+        .parse::<typst::syntax::package::PackageSpec>()
+        .unwrap();
+    let unvendored = "@preview/tablex:0.0.9"
+        .parse::<typst::syntax::package::PackageSpec>()
+        .unwrap();
+    assert_eq!(manifest.packages().vendored(), &[vendored]);
+    assert_eq!(manifest.packages().unvendored(), &[unvendored]);
     assert_eq!(manifest.fonts()[0].path(), "fonts/test.ttf");
     assert_eq!(manifest.fonts()[0].index(), 2);
     assert_eq!(manifest.fonts()[0].families(), ["Test"]);
@@ -508,6 +523,31 @@ fn pack_construction_rejects_font_paths_reserved_for_project_files() {
 }
 
 #[test]
+fn pack_construction_rejects_font_paths_at_reserved_namespace_roots() {
+    for (path, conflicting_role) in [
+        ("project", PackPathRole::ProjectFile),
+        ("packages", PackPathRole::PackageFile),
+    ] {
+        let manifest = format!(
+            "format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[[fonts]]\npath = \"{path}\"\nfamilies = [\"Informational\"]\n"
+        );
+        let bytes = raw_stored_zip(&[
+            (MANIFEST_PATH, manifest.as_bytes()),
+            ("project/main.typ", b"Hello"),
+            (path, b"not a font"),
+        ]);
+
+        assert!(matches!(
+            Pack::from_bytes(bytes),
+            Err(PackReadError::Invariant(PackInvariantError::ReservedFontPath {
+                path: ref actual,
+                conflicting_role: actual_role,
+            })) if actual == path && actual_role == conflicting_role
+        ));
+    }
+}
+
+#[test]
 fn a_constructed_pack_builds_a_world_without_revalidation() {
     let pack = Pack::builder("main.typ")
         .file("main.typ", Vec::new())
@@ -718,6 +758,27 @@ fn read_rejects_distinct_archive_entries_with_one_canonical_identity() {
                 ..
             }
         )) if canonical == "project/main.typ"
+    ));
+}
+
+#[test]
+fn read_rejects_distinct_raw_names_with_one_decoded_identity() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    let bytes = raw_stored_zip_with_raw_names(&[
+        (MANIFEST_PATH.as_bytes(), false, manifest),
+        (b"project/main.typ", false, b"Hello"),
+        ("project/é.txt".as_bytes(), true, b"UTF-8"),
+        (b"project/\x82.txt", false, b"CP437"),
+    ]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::Invariant(
+            PackInvariantError::CanonicalArchiveEntryCollision {
+                ref canonical,
+                ..
+            }
+        )) if canonical == "project/é.txt"
     ));
 }
 
@@ -1558,12 +1619,18 @@ Rows: #csv("data.csv").len()
         let result = Packer::new(&project, "main.typ")
             .system_fonts(false)
             .external_resource("main.typ")
+            .external_resource("assets")
+            .external_resource("assets/logo.png")
             .pack();
 
         assert!(matches!(
             result,
             Err(PackerError::Build(PackBuildError::Invariant(
-                PackInvariantError::EntrypointIsExternalResource(ref path)
+                PackInvariantError::PathRoleConflict {
+                    ref path,
+                    first: PackPathRole::ProjectFile,
+                    second: PackPathRole::ExternalProjectResource,
+                }
             ))) if path == "main.typ"
         ));
     }
@@ -1602,7 +1669,7 @@ Rows: #csv("data.csv").len()
             result,
             Err(PackerError::Build(PackBuildError::Invariant(
                 PackInvariantError::PathTreeConflict {
-                    ancestor_role: PackPathRole::Entrypoint,
+                    ancestor_role: PackPathRole::ProjectFile,
                     descendant_role: PackPathRole::ExternalProjectResource,
                     package: None,
                     ..
@@ -1810,42 +1877,28 @@ Rows: #csv("data.csv").len()
     }
 
     #[test]
-    fn concurrent_successful_discovery_fallback_records_one_provenance_entry() {
-        let entered = Arc::new(std::sync::Barrier::new(3));
-        let release = Arc::new(std::sync::Barrier::new(3));
-        let discovery = crate::external_resource::Discovery::new(
-            vec![Box::new(BlockingProjectFile {
-                path: "shared.bin".to_owned(),
-                data: Bytes::new(b"external".to_vec()),
-                entered: Arc::clone(&entered),
-                release: Arc::clone(&release),
-            })],
-            true,
-            std::collections::BTreeSet::new(),
+    fn explicit_and_inferred_provenance_yield_one_packer_declaration() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        fs::write(project.join("main.typ"), "#read(\"shared.bin\")").unwrap();
+        let (reference, calls) = MemoryProjectFile::tracked("shared.bin", b"external".to_vec());
+
+        let outcome = Packer::new(&project, "main.typ")
+            .system_fonts(false)
+            .project_resource_policy(ProjectResourcePolicy::AllowExternalFallback)
+            .external_resource("shared.bin")
+            .external_resource_reference(reference)
+            .pack()
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert_eq!(outcome.report.external_resources, ["shared.bin"]);
+        assert_eq!(
+            outcome.pack.external_resources().collect::<Vec<_>>(),
+            ["shared.bin"]
         );
-        let id = project_file_id("shared.bin");
-
-        std::thread::scope(|scope| {
-            let first = scope.spawn(|| {
-                discovery.file(id, || Err(FileError::NotFound(PathBuf::from("shared.bin"))))
-            });
-            let second = scope.spawn(|| {
-                discovery.file(id, || Err(FileError::NotFound(PathBuf::from("shared.bin"))))
-            });
-            entered.wait();
-            release.wait();
-
-            assert_eq!(
-                first.join().unwrap().unwrap(),
-                Bytes::new(b"external".to_vec())
-            );
-            assert_eq!(
-                second.join().unwrap().unwrap(),
-                Bytes::new(b"external".to_vec())
-            );
-        });
-
-        assert_eq!(discovery.external_resources(), vec!["shared.bin"]);
+        assert!(outcome.pack.file("shared.bin").is_none());
     }
 
     #[cfg(feature = "embedded-fonts")]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16,6 +16,44 @@ fn tiny_png() -> Vec<u8> {
     tiny_skia::Pixmap::new(4, 4).unwrap().encode_png().unwrap()
 }
 
+#[cfg(feature = "embedded-fonts")]
+fn embedded_font_data() -> Vec<u8> {
+    typst_kit::fonts::embedded()
+        .next()
+        .expect("Typst embedded fonts are available")
+        .0
+        .data()
+        .to_vec()
+}
+
+#[cfg(feature = "embedded-fonts")]
+fn two_face_collection(font: &[u8]) -> Vec<u8> {
+    fn adjusted_font(font: &[u8], base: usize) -> Vec<u8> {
+        let mut adjusted = font.to_vec();
+        let table_count = usize::from(u16::from_be_bytes([font[4], font[5]]));
+        for table in 0..table_count {
+            let offset = 12 + table * 16 + 8;
+            let original = u32::from_be_bytes(font[offset..offset + 4].try_into().unwrap());
+            let adjusted_offset = original + u32::try_from(base).unwrap();
+            adjusted[offset..offset + 4].copy_from_slice(&adjusted_offset.to_be_bytes());
+        }
+        adjusted
+    }
+
+    let first_offset = 20;
+    let second_offset = (first_offset + font.len() + 3) & !3;
+    let mut collection = Vec::with_capacity(second_offset + font.len());
+    collection.extend_from_slice(b"ttcf");
+    collection.extend_from_slice(&0x0001_0000u32.to_be_bytes());
+    collection.extend_from_slice(&2u32.to_be_bytes());
+    collection.extend_from_slice(&u32::try_from(first_offset).unwrap().to_be_bytes());
+    collection.extend_from_slice(&u32::try_from(second_offset).unwrap().to_be_bytes());
+    collection.extend_from_slice(&adjusted_font(font, first_offset));
+    collection.resize(second_offset, 0);
+    collection.extend_from_slice(&adjusted_font(font, second_offset));
+    collection
+}
+
 struct MemoryProjectFile {
     path: String,
     data: Bytes,
@@ -420,7 +458,6 @@ fn pack_construction_rejects_conflicting_project_tree_roles() {
                 ref descendant,
                 ancestor_role: PackPathRole::ProjectFile,
                 descendant_role: PackPathRole::ExternalProjectResource,
-                package: None,
             }
         )) if ancestor == "assets" && descendant == "assets/logo.png"
     ));
@@ -440,7 +477,6 @@ fn pack_construction_rejects_conflicting_project_tree_roles() {
                 ref descendant,
                 ancestor_role: PackPathRole::ProjectFile,
                 descendant_role: PackPathRole::ExternalProjectResource,
-                package: None,
             }
         )) if ancestor == "assets" && descendant == "assets/logo.png"
     ));
@@ -480,6 +516,59 @@ fn pack_construction_rejects_conflicting_package_roles() {
 }
 
 #[test]
+fn pack_construction_rejects_package_declaration_data_disagreement() {
+    let missing_manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[packages]\nvendored = [\"@local/example:1.0.0\"]\n";
+    let missing = raw_stored_zip(&[
+        (MANIFEST_PATH, missing_manifest),
+        ("project/main.typ", b"Hello"),
+    ]);
+    assert!(matches!(
+        Pack::from_bytes(missing),
+        Err(PackReadError::Invariant(
+            PackInvariantError::MissingVendoredPackageData(ref spec)
+        )) if spec == "@local/example:1.0.0"
+    ));
+
+    let undeclared_manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    let undeclared = raw_stored_zip(&[
+        (MANIFEST_PATH, undeclared_manifest),
+        ("project/main.typ", b"Hello"),
+        ("packages/local/example/1.0.0/lib.typ", b"Hello"),
+    ]);
+    assert!(matches!(
+        Pack::from_bytes(undeclared),
+        Err(PackReadError::Invariant(
+            PackInvariantError::UndeclaredPackageData(ref spec)
+        )) if spec == "@local/example:1.0.0"
+    ));
+}
+
+#[test]
+fn pack_construction_rejects_conflicting_package_file_tree_paths() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[packages]\nvendored = [\"@local/example:1.0.0\"]\n";
+    let bytes = raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+        ("packages/local/example/1.0.0/lib", b"file"),
+        ("packages/local/example/1.0.0/lib/child.typ", b"child"),
+    ]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::Invariant(
+            PackInvariantError::PackagePathTreeConflict {
+                ref package,
+                ref ancestor,
+                ref descendant,
+                ..
+            }
+        )) if package == "@local/example:1.0.0"
+            && ancestor == "lib"
+            && descendant == "lib/child.typ"
+    ));
+}
+
+#[test]
 fn pack_construction_rejects_invalid_contained_font_data() {
     let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[[fonts]]\npath = \"custom-font.bin\"\nindex = 3\nfamilies = [\"Informational\"]\n";
     let bytes = raw_stored_zip(&[
@@ -490,8 +579,8 @@ fn pack_construction_rejects_invalid_contained_font_data() {
 
     assert!(matches!(
         Pack::from_bytes(bytes),
-        Err(PackReadError::Invariant(PackInvariantError::InvalidFont {
-            path: Some(ref path),
+        Err(PackReadError::Invariant(PackInvariantError::InvalidFontData {
+            ref path,
             index: 3,
         })) if path == "custom-font.bin"
     ));
@@ -501,10 +590,55 @@ fn pack_construction_rejects_invalid_contained_font_data() {
 fn pack_builder_reports_invalid_font_data_as_a_shared_invariant() {
     assert!(matches!(
         Pack::builder("main.typ").font(b"not a font".to_vec(), 2),
-        Err(PackBuildError::Invariant(PackInvariantError::InvalidFont {
-            path: None,
-            index: 2,
-        }))
+        Err(PackBuildError::Invariant(
+            PackInvariantError::InvalidFontInput { index: 2 }
+        ))
+    ));
+}
+
+#[cfg(feature = "embedded-fonts")]
+#[test]
+fn pack_accepts_shared_multi_face_custom_font_data_and_informational_families() {
+    let collection = two_face_collection(&embedded_font_data());
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[[fonts]]\npath = \"custom-font.data\"\nindex = 0\nfamilies = [\"Not the parsed family\"]\n[[fonts]]\npath = \"custom-font.data\"\nindex = 1\nfamilies = [\"Also informational\"]\n";
+    let pack = Pack::from_bytes(raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+        ("custom-font.data", &collection),
+    ]))
+    .unwrap();
+
+    assert_eq!(pack.fonts().len(), 2);
+    assert_eq!(pack.fonts()[0].manifest().path(), "custom-font.data");
+    assert_eq!(
+        pack.fonts()[0].manifest().families(),
+        ["Not the parsed family"]
+    );
+    assert_eq!(pack.fonts()[1].manifest().index(), 1);
+    assert_eq!(
+        pack.fonts()[1].manifest().families(),
+        ["Also informational"]
+    );
+}
+
+#[cfg(feature = "embedded-fonts")]
+#[test]
+fn pack_rejects_duplicate_font_faces() {
+    let font = embedded_font_data();
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[[fonts]]\npath = \"font.data\"\nfamilies = [\"A\"]\n[[fonts]]\npath = \"font.data\"\nfamilies = [\"B\"]\n";
+
+    assert!(matches!(
+        Pack::from_bytes(raw_stored_zip(&[
+            (MANIFEST_PATH, manifest),
+            ("project/main.typ", b"Hello"),
+            ("font.data", &font),
+        ])),
+        Err(PackReadError::Invariant(
+            PackInvariantError::DuplicateFontFace {
+                ref path,
+                index: 0,
+            }
+        )) if path == "font.data"
     ));
 }
 
@@ -545,6 +679,62 @@ fn pack_construction_rejects_font_paths_at_reserved_namespace_roots() {
             })) if actual == path && actual_role == conflicting_role
         ));
     }
+}
+
+#[test]
+fn pack_construction_rejects_conflicting_font_data_tree_paths() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[[fonts]]\npath = \"fonts/a\"\nfamilies = [\"A\"]\n[[fonts]]\npath = \"fonts/a/face.ttf\"\nfamilies = [\"B\"]\n";
+    let bytes = raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+        ("fonts/a", b"not a font"),
+        ("fonts/a/face.ttf", b"not a font"),
+    ]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::Invariant(
+            PackInvariantError::PathTreeConflict {
+                ref ancestor,
+                ancestor_role: PackPathRole::FontData,
+                ref descendant,
+                descendant_role: PackPathRole::FontData,
+            }
+        )) if ancestor == "fonts/a" && descendant == "fonts/a/face.ttf"
+    ));
+}
+
+#[test]
+fn font_path_failures_precede_entrypoint_failures() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"missing.typ\"\n[[fonts]]\npath = \"../font.ttf\"\nfamilies = [\"Invalid\"]\n";
+
+    assert!(matches!(
+        Pack::from_bytes(raw_stored_zip(&[(MANIFEST_PATH, manifest)])),
+        Err(PackReadError::Invariant(PackInvariantError::InvalidPath {
+            role: PackPathRole::FontData,
+            ..
+        }))
+    ));
+}
+
+#[test]
+fn invariant_diagnostics_do_not_expose_optional_field_formatting() {
+    let tree = PackInvariantError::PathTreeConflict {
+        ancestor: "assets".to_owned(),
+        ancestor_role: PackPathRole::ProjectFile,
+        descendant: "assets/logo.png".to_owned(),
+        descendant_role: PackPathRole::ExternalProjectResource,
+    };
+    assert_eq!(
+        tree.to_string(),
+        "project file path `assets` conflicts with External Project Resource descendant `assets/logo.png`"
+    );
+
+    let font = PackInvariantError::InvalidFontInput { index: 2 };
+    assert_eq!(
+        font.to_string(),
+        "font input does not contain a valid face at index 2"
+    );
 }
 
 #[test]
@@ -709,6 +899,22 @@ fn read_rejects_unsafe_unknown_directories_before_ignoring_them() {
         Pack::from_bytes(buffer.into_inner()),
         Err(PackReadError::UnsafeEntry(_))
     ));
+}
+
+#[test]
+fn read_accepts_safe_unknown_entries_and_rewrite_drops_them() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    let pack = Pack::from_bytes(raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+        ("future/data.bin", b"ignored"),
+    ]))
+    .unwrap();
+
+    let mut rewritten =
+        zip::ZipArchive::new(std::io::Cursor::new(pack.to_bytes().unwrap())).unwrap();
+    assert!(rewritten.by_name("future/data.bin").is_err());
+    assert_eq!(rewritten.by_name("project/main.typ").unwrap().size(), 5);
 }
 
 #[test]
@@ -1654,7 +1860,6 @@ Rows: #csv("data.csv").len()
                 PackInvariantError::PathTreeConflict {
                     ancestor_role: PackPathRole::ExternalProjectResource,
                     descendant_role: PackPathRole::ExternalProjectResource,
-                    package: None,
                     ..
                 }
             )))
@@ -1671,7 +1876,6 @@ Rows: #csv("data.csv").len()
                 PackInvariantError::PathTreeConflict {
                     ancestor_role: PackPathRole::ProjectFile,
                     descendant_role: PackPathRole::ExternalProjectResource,
-                    package: None,
                     ..
                 }
             )))

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -366,6 +366,20 @@ fn manifest_rejects_future_version() {
 }
 
 #[test]
+fn manifest_rejects_version_zero_and_unknown_version_one_fields() {
+    assert!(matches!(
+        PackManifest::from_toml("format-version = 0\n[project]\nentrypoint = \"main.typ\"\n"),
+        Err(PackManifestError::UnsupportedVersion(0))
+    ));
+    assert!(matches!(
+        PackManifest::from_toml(
+            "format-version = 1\nunknown = true\n[project]\nentrypoint = \"main.typ\"\n"
+        ),
+        Err(PackManifestError::Parse(_))
+    ));
+}
+
+#[test]
 fn manifest_dispatches_version_before_interpreting_version_specific_fields() {
     let text = "format-version = 99\nfuture-field = true\n[project]\nentrypoint = \"main.typ\"\n";
 
@@ -597,6 +611,53 @@ fn pack_construction_rejects_invalid_contained_font_data() {
             ref path,
             index: 3,
         })) if path == "custom-font.bin"
+    ));
+}
+
+#[test]
+fn pack_construction_rejects_missing_font_data() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[[fonts]]\npath = \"fonts/vendor/font.ttf\"\n";
+    let bytes = raw_stored_zip(&[(MANIFEST_PATH, manifest), ("project/main.typ", b"Hello")]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::Invariant(PackInvariantError::MissingFontData(ref path)))
+            if path == "fonts/vendor/font.ttf"
+    ));
+}
+
+#[cfg(feature = "embedded-fonts")]
+#[test]
+fn read_preserves_nested_portable_font_paths() {
+    let font = embedded_font_data();
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[[fonts]]\npath = \"fonts/vendor/font.ttf\"\n";
+    let pack = Pack::from_bytes(raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+        ("fonts/vendor/font.ttf", &font),
+    ]))
+    .unwrap();
+
+    assert_eq!(pack.fonts()[0].manifest().path(), "fonts/vendor/font.ttf");
+}
+
+#[cfg(feature = "embedded-fonts")]
+#[test]
+fn pack_construction_rejects_a_missing_face_in_valid_font_data() {
+    let font = embedded_font_data();
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[[fonts]]\npath = \"fonts/vendor/font.ttf\"\nindex = 99\n";
+    let bytes = raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+        ("fonts/vendor/font.ttf", &font),
+    ]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::Invariant(PackInvariantError::InvalidFontData {
+            ref path,
+            index: 99,
+        })) if path == "fonts/vendor/font.ttf"
     ));
 }
 
@@ -909,6 +970,38 @@ fn pack_builder_rejects_external_project_resource_file_conflicts() {
 }
 
 #[test]
+fn repeated_builder_calls_replace_data_within_the_same_role() {
+    let spec = "@local/example:1.0.0"
+        .parse::<typst::syntax::package::PackageSpec>()
+        .unwrap();
+    let pack = Pack::builder("main.typ")
+        .file("main.typ", b"first".to_vec())
+        .unwrap()
+        .file("main.typ", b"second".to_vec())
+        .unwrap()
+        .package_file(spec.clone(), "lib.typ", b"first".to_vec())
+        .unwrap()
+        .package_file(spec.clone(), "lib.typ", b"second".to_vec())
+        .unwrap()
+        .external_resource("optional.bin")
+        .unwrap()
+        .external_resource("optional.bin")
+        .unwrap()
+        .build()
+        .unwrap();
+
+    assert_eq!(pack.file("main.typ").unwrap().as_slice(), b"second");
+    assert_eq!(
+        pack.package_file(&spec, "lib.typ").unwrap().as_slice(),
+        b"second"
+    );
+    assert_eq!(
+        pack.external_resources().collect::<Vec<_>>(),
+        ["optional.bin"]
+    );
+}
+
+#[test]
 fn read_rejects_archives_without_manifest() {
     use std::io::Write;
     let mut buffer = std::io::Cursor::new(Vec::new());
@@ -919,6 +1012,14 @@ fn read_rejects_archives_without_manifest() {
     zip.finish().unwrap();
     let result = Pack::from_bytes(buffer.into_inner());
     assert!(matches!(result, Err(PackReadError::MissingManifest)));
+}
+
+#[test]
+fn read_reports_corrupt_zip_data_as_an_archive_error() {
+    assert!(matches!(
+        Pack::from_bytes(b"not a zip archive".to_vec()),
+        Err(PackReadError::Zip(_))
+    ));
 }
 
 #[test]
@@ -1013,6 +1114,26 @@ fn read_accepts_safe_unknown_entries_and_rewrite_drops_them() {
 }
 
 #[test]
+fn read_accepts_safe_directory_entries() {
+    use std::io::Write as _;
+
+    let mut buffer = std::io::Cursor::new(Vec::new());
+    let mut zip = zip::ZipWriter::new(&mut buffer);
+    let options = zip::write::SimpleFileOptions::default();
+    zip.add_directory("project/", options).unwrap();
+    zip.add_directory("future/nested/", options).unwrap();
+    zip.start_file(MANIFEST_PATH, options).unwrap();
+    zip.write_all(b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n")
+        .unwrap();
+    zip.start_file("project/main.typ", options).unwrap();
+    zip.write_all(b"Hello").unwrap();
+    zip.finish().unwrap();
+
+    let pack = Pack::from_bytes(buffer.into_inner()).unwrap();
+    assert_eq!(pack.file("main.typ").unwrap().as_slice(), b"Hello");
+}
+
+#[test]
 fn read_rejects_a_windows_prefix_hidden_by_a_current_directory_alias() {
     let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
     let bytes = raw_stored_zip(&[
@@ -1075,6 +1196,53 @@ fn read_rejects_distinct_archive_entries_with_one_canonical_identity() {
                 ..
             }
         )) if canonical == "project/main.typ"
+    ));
+}
+
+#[test]
+fn read_rejects_canonical_collisions_for_package_and_font_entries() {
+    let package_manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[packages]\nvendored = [\"@local/example:1.0.0\"]\n";
+    let package = raw_stored_zip(&[
+        (MANIFEST_PATH, package_manifest),
+        ("project/main.typ", b"Hello"),
+        ("packages/local/example/1.0.0/lib.typ", b"first"),
+        ("packages/local/example/1.0.0/./lib.typ", b"second"),
+    ]);
+    assert!(matches!(
+        Pack::from_bytes(package),
+        Err(PackReadError::Invariant(
+            PackInvariantError::CanonicalArchiveEntryCollision { ref canonical, .. }
+        )) if canonical == "packages/local/example/1.0.0/lib.typ"
+    ));
+
+    let font_manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[[fonts]]\npath = \"fonts/vendor/font.ttf\"\n";
+    let font = raw_stored_zip(&[
+        (MANIFEST_PATH, font_manifest),
+        ("project/main.typ", b"Hello"),
+        ("fonts/vendor/font.ttf", b"first"),
+        ("fonts/vendor/./font.ttf", b"second"),
+    ]);
+    assert!(matches!(
+        Pack::from_bytes(font),
+        Err(PackReadError::Invariant(
+            PackInvariantError::CanonicalArchiveEntryCollision { ref canonical, .. }
+        )) if canonical == "fonts/vendor/font.ttf"
+    ));
+}
+
+#[test]
+fn read_rejects_malformed_package_entry_layouts() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    let bytes = raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+        ("packages/local/example/1.0.0", b"missing file path"),
+    ]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::InvalidEntry { ref entry, .. })
+            if entry == "packages/local/example/1.0.0"
     ));
 }
 
@@ -1466,9 +1634,9 @@ fn packed_and_undeclared_project_paths_do_not_consult_external_resource_referenc
         .unwrap()
         .build()
         .unwrap();
-    let (loader, calls) = MemoryProjectFile::tracked("resource.bin", b"external".to_vec());
+    let (provider, calls) = MemoryProjectFile::tracked("resource.bin", b"external".to_vec());
     let world = PackWorld::builder(packed)
-        .external_resource_reference(loader)
+        .external_resource_reference(provider)
         .build();
     assert_eq!(
         world
@@ -1484,9 +1652,9 @@ fn packed_and_undeclared_project_paths_do_not_consult_external_resource_referenc
         .unwrap()
         .build()
         .unwrap();
-    let (loader, calls) = MemoryProjectFile::tracked("missing.bin", b"external".to_vec());
+    let (provider, calls) = MemoryProjectFile::tracked("missing.bin", b"external".to_vec());
     let world = PackWorld::builder(undeclared)
-        .external_resource_reference(loader)
+        .external_resource_reference(provider)
         .build();
     assert!(matches!(
         world.file(project_file_id("missing.bin")),
@@ -1506,9 +1674,9 @@ fn package_requests_do_not_consult_external_resource_references() {
         .unwrap()
         .build()
         .unwrap();
-    let (loader, calls) = MemoryProjectFile::tracked("lib.typ", b"external".to_vec());
+    let (provider, calls) = MemoryProjectFile::tracked("lib.typ", b"external".to_vec());
     let world = PackWorld::builder(pack)
-        .external_resource_reference(loader)
+        .external_resource_reference(provider)
         .build();
     let spec = typst::syntax::package::PackageSpec::from_str("@local/example:1.0.0").unwrap();
     let id = RootedPath::new(
@@ -1904,6 +2072,33 @@ Rows: #csv("data.csv").len()
     }
 
     #[test]
+    fn explicit_typst_manifest_resource_remains_a_slot_after_discovery() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        fs::write(project.join("main.typ"), "#read(\"typst.toml\")").unwrap();
+        fs::write(
+            project.join("typst.toml"),
+            "[package]\nname = \"representative\"\nversion = \"1.0.0\"\nentrypoint = \"main.typ\"\n",
+        )
+        .unwrap();
+
+        let outcome = Packer::new(&project, "main.typ")
+            .system_fonts(false)
+            .external_resource("typst.toml")
+            .pack()
+            .unwrap();
+
+        assert_eq!(outcome.report.external_resources, ["typst.toml"]);
+        assert!(!outcome.report.files.iter().any(|path| path == "typst.toml"));
+        assert!(outcome.pack.file("typst.toml").is_none());
+        assert_eq!(
+            outcome.pack.external_resources().collect::<Vec<_>>(),
+            ["typst.toml"]
+        );
+    }
+
+    #[test]
     fn unrequested_external_project_resource_is_still_declared() {
         let dir = tempfile::tempdir().unwrap();
         let project = dir.path().join("project");
@@ -2045,11 +2240,11 @@ Rows: #csv("data.csv").len()
         )
         .unwrap();
 
-        let (strict_loader, strict_calls) =
+        let (strict_provider, strict_calls) =
             MemoryProjectFile::tracked("assets/logo.png", tiny_png());
         let strict = Packer::new(&project, "main.typ")
             .system_fonts(false)
-            .external_resource_reference(strict_loader)
+            .external_resource_reference(strict_provider)
             .pack();
         assert!(matches!(strict, Err(PackerError::Compile { .. })));
         assert_eq!(strict_calls.load(Ordering::Relaxed), 0);
@@ -2164,14 +2359,14 @@ Rows: #csv("data.csv").len()
             }
         });
 
-        let (loader, calls) = MemoryProjectFile::tracked(
+        let (provider, calls) = MemoryProjectFile::tracked(
             "chapter.typ",
             b"#let chapter = rect(width: 2pt, height: 2pt)".to_vec(),
         );
         let outcome = Packer::new(&project, "main.typ")
             .system_fonts(false)
             .project_resource_policy(ProjectResourcePolicy::AllowExternalFallback)
-            .external_resource_reference(loader)
+            .external_resource_reference(provider)
             .pack()
             .unwrap();
         writer.join().unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -101,6 +101,90 @@ fn project_file_id(path: &str) -> FileId {
     RootedPath::new(VirtualRoot::Project, VirtualPath::new(path).unwrap()).intern()
 }
 
+fn raw_stored_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    fn crc32(data: &[u8]) -> u32 {
+        let mut crc = !0u32;
+        for byte in data {
+            crc ^= u32::from(*byte);
+            for _ in 0..8 {
+                crc = (crc >> 1) ^ (0xedb8_8320 & (0u32.wrapping_sub(crc & 1)));
+            }
+        }
+        !crc
+    }
+
+    fn u16_bytes(value: usize) -> [u8; 2] {
+        u16::try_from(value).unwrap().to_le_bytes()
+    }
+
+    fn u32_bytes(value: usize) -> [u8; 4] {
+        u32::try_from(value).unwrap().to_le_bytes()
+    }
+
+    let mut archive = Vec::new();
+    let mut central_entries = Vec::new();
+    for (name, data) in entries {
+        let offset = archive.len();
+        let crc = crc32(data);
+        archive.extend_from_slice(b"PK\x03\x04");
+        archive.extend_from_slice(&20u16.to_le_bytes());
+        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(&crc.to_le_bytes());
+        archive.extend_from_slice(&u32_bytes(data.len()));
+        archive.extend_from_slice(&u32_bytes(data.len()));
+        archive.extend_from_slice(&u16_bytes(name.len()));
+        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(name.as_bytes());
+        archive.extend_from_slice(data);
+        central_entries.push((name, data.len(), crc, offset));
+    }
+
+    let central_start = archive.len();
+    for (name, size, crc, offset) in central_entries {
+        archive.extend_from_slice(b"PK\x01\x02");
+        archive.extend_from_slice(&20u16.to_le_bytes());
+        archive.extend_from_slice(&20u16.to_le_bytes());
+        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(&crc.to_le_bytes());
+        archive.extend_from_slice(&u32_bytes(size));
+        archive.extend_from_slice(&u32_bytes(size));
+        archive.extend_from_slice(&u16_bytes(name.len()));
+        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(&0u16.to_le_bytes());
+        archive.extend_from_slice(&0u32.to_le_bytes());
+        archive.extend_from_slice(&u32_bytes(offset));
+        archive.extend_from_slice(name.as_bytes());
+    }
+    let central_size = archive.len() - central_start;
+    archive.extend_from_slice(b"PK\x05\x06");
+    archive.extend_from_slice(&0u16.to_le_bytes());
+    archive.extend_from_slice(&0u16.to_le_bytes());
+    archive.extend_from_slice(&u16_bytes(entries.len()));
+    archive.extend_from_slice(&u16_bytes(entries.len()));
+    archive.extend_from_slice(&u32_bytes(central_size));
+    archive.extend_from_slice(&u32_bytes(central_start));
+    archive.extend_from_slice(&0u16.to_le_bytes());
+    archive
+}
+
+fn with_first_zip_entry_unix_mode(mut archive: Vec<u8>, mode: u32) -> Vec<u8> {
+    let eocd = archive.len() - 22;
+    let central_start =
+        u32::from_le_bytes(archive[eocd + 16..eocd + 20].try_into().unwrap()) as usize;
+    archive[central_start + 4..central_start + 6]
+        .copy_from_slice(&((3u16 << 8) | 20).to_le_bytes());
+    archive[central_start + 38..central_start + 42].copy_from_slice(&(mode << 16).to_le_bytes());
+    archive
+}
+
 #[test]
 fn manifest_roundtrip() {
     let manifest = PackManifest::from_toml(
@@ -123,7 +207,7 @@ fn manifest_roundtrip() {
         "#,
     )
     .unwrap();
-    assert_eq!(manifest.project.entrypoint, "main.typ");
+    assert_eq!(manifest.project().entrypoint(), "main.typ");
     assert_eq!(manifest.vendored_packages().unwrap().len(), 1);
     assert_eq!(manifest.unvendored_packages().unwrap().len(), 1);
 
@@ -135,75 +219,87 @@ fn manifest_roundtrip() {
 }
 
 #[test]
-fn old_manifest_has_no_external_project_resources() {
-    let manifest =
-        PackManifest::from_toml("format-version = 1\n[project]\nentrypoint = \"main.typ\"\n")
-            .unwrap();
-
-    assert!(manifest.project.external_resources.is_empty());
-}
-
-#[test]
-fn manifest_rejects_unsafe_external_project_resource_path() {
-    let result = PackManifest::from_toml(
-        r#"
-        format-version = 1
-
-        [project]
-        entrypoint = "main.typ"
-        external-resources = ["../secret.png"]
-        "#,
-    );
-
-    assert!(matches!(
-        result,
-        Err(PackManifestError::InvalidExternalResource { .. })
-    ));
-}
-
-#[test]
-fn manifest_normalizes_external_project_resources_deterministically() {
+fn manifest_declarations_are_exposed_read_only_through_accessors() {
     let manifest = PackManifest::from_toml(
         r#"
         format-version = 1
 
         [project]
         entrypoint = "main.typ"
-        external-resources = ["z.png", "assets/../logo.png", "./logo.png"]
+        external-resources = ["logo.png"]
+
+        [packages]
+        vendored = ["@preview/cetz:0.3.4"]
+        external = ["@preview/tablex:0.0.9"]
+
+        [[fonts]]
+        path = "fonts/test.ttf"
+        index = 2
+        families = ["Test"]
+
+        [metadata]
+        name = "Test pack"
+        authors = ["A. U. Thor"]
         "#,
     )
     .unwrap();
 
+    assert_eq!(manifest.format_version(), 1);
+    assert_eq!(manifest.project().entrypoint(), "main.typ");
     assert_eq!(
-        manifest
-            .project
-            .external_resources
-            .iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>(),
-        ["logo.png", "z.png"]
+        manifest.project().external_resources().collect::<Vec<_>>(),
+        ["logo.png"]
     );
-    assert!(
-        manifest
-            .to_toml()
-            .contains("external-resources = [\n    \"logo.png\",\n    \"z.png\",\n]")
-    );
+    assert_eq!(manifest.packages().vendored(), ["@preview/cetz:0.3.4"]);
+    assert_eq!(manifest.packages().unvendored(), ["@preview/tablex:0.0.9"]);
+    assert_eq!(manifest.fonts()[0].path(), "fonts/test.ttf");
+    assert_eq!(manifest.fonts()[0].index(), 2);
+    assert_eq!(manifest.fonts()[0].families(), ["Test"]);
+    assert_eq!(manifest.metadata().unwrap().name(), Some("Test pack"));
+    assert_eq!(manifest.metadata().unwrap().authors(), ["A. U. Thor"]);
 }
 
 #[test]
-fn manifest_validation_rejects_noncanonical_external_project_resource_path() {
-    let mut manifest =
+fn old_manifest_has_no_external_project_resources() {
+    let manifest =
         PackManifest::from_toml("format-version = 1\n[project]\nentrypoint = \"main.typ\"\n")
             .unwrap();
-    manifest
-        .project
-        .external_resources
-        .insert("assets/../logo.png".to_owned());
+
+    assert!(manifest.project().external_resources().next().is_none());
+}
+
+#[test]
+fn pack_rejects_unsafe_external_project_resource_declarations() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\nexternal-resources = [\"../secret.png\"]\n";
+    let bytes = raw_stored_zip(&[(MANIFEST_PATH, manifest), ("project/main.typ", b"Hello")]);
 
     assert!(matches!(
-        manifest.validate(),
-        Err(PackManifestError::InvalidExternalResource { .. })
+        Pack::from_bytes(bytes),
+        Err(PackReadError::Invariant(PackInvariantError::InvalidPath {
+            role: PackPathRole::ExternalProjectResource,
+            ..
+        }))
     ));
+}
+
+#[test]
+fn pack_normalizes_external_project_resources_deterministically() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\nexternal-resources = [\"z.png\", \"assets/../logo.png\", \"./logo.png\"]\n";
+    let pack = Pack::from_bytes(raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+    ]))
+    .unwrap();
+
+    assert_eq!(
+        pack.external_resources().collect::<Vec<_>>(),
+        ["logo.png", "z.png"]
+    );
+    assert!(
+        pack.manifest()
+            .to_toml()
+            .contains("external-resources = [\n    \"logo.png\",\n    \"z.png\",\n]")
+    );
 }
 
 #[test]
@@ -217,9 +313,232 @@ fn manifest_rejects_future_version() {
 }
 
 #[test]
-fn builder_requires_entrypoint_file() {
-    let result = Pack::builder("main.typ").build();
-    assert!(matches!(result, Err(PackBuildError::MissingEntrypoint(_))));
+fn manifest_dispatches_version_before_interpreting_version_specific_fields() {
+    let text = "format-version = 99\nfuture-field = true\n[project]\nentrypoint = \"main.typ\"\n";
+
+    assert!(matches!(
+        PackManifest::from_toml(text),
+        Err(PackManifestError::UnsupportedVersion(99))
+    ));
+    assert!(toml::from_str::<PackManifest>(text).is_err());
+}
+
+#[test]
+fn pack_construction_requires_a_contained_entrypoint() {
+    let built = Pack::builder("main.typ").build();
+    assert!(matches!(
+        built,
+        Err(PackBuildError::Invariant(
+            PackInvariantError::MissingEntrypoint(ref path)
+        )) if path == "main.typ"
+    ));
+
+    use std::io::Write;
+    let mut buffer = std::io::Cursor::new(Vec::new());
+    let mut zip = zip::ZipWriter::new(&mut buffer);
+    zip.start_file(MANIFEST_PATH, zip::write::SimpleFileOptions::default())
+        .unwrap();
+    zip.write_all(b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n")
+        .unwrap();
+    zip.finish().unwrap();
+
+    let read = Pack::from_bytes(buffer.into_inner());
+    assert!(matches!(
+        read,
+        Err(PackReadError::Invariant(
+            PackInvariantError::MissingEntrypoint(ref path)
+        )) if path == "main.typ"
+    ));
+}
+
+#[test]
+fn pack_builder_rejects_paths_that_cannot_name_root_relative_files() {
+    assert!(matches!(
+        Pack::builder("").build(),
+        Err(PackBuildError::Invariant(PackInvariantError::InvalidPath {
+            role: PackPathRole::Entrypoint,
+            ..
+        }))
+    ));
+    assert!(matches!(
+        Pack::builder("main.typ").file("/main.typ", Vec::new()),
+        Err(PackBuildError::Invariant(PackInvariantError::InvalidPath {
+            role: PackPathRole::ProjectFile,
+            ..
+        }))
+    ));
+    assert!(matches!(
+        Pack::builder("main.typ").external_resource("."),
+        Err(PackBuildError::Invariant(PackInvariantError::InvalidPath {
+            role: PackPathRole::ExternalProjectResource,
+            ..
+        }))
+    ));
+    for path in ["C:outside.txt", "./C:/outside.txt"] {
+        assert!(matches!(
+            Pack::builder("main.typ").file(path, Vec::new()),
+            Err(PackBuildError::Invariant(PackInvariantError::InvalidPath {
+                role: PackPathRole::ProjectFile,
+                ..
+            }))
+        ));
+    }
+}
+
+#[test]
+fn pack_construction_rejects_conflicting_project_tree_roles() {
+    let built = Pack::builder("main.typ")
+        .file("main.typ", Vec::new())
+        .unwrap()
+        .file("assets", b"packed".to_vec())
+        .unwrap()
+        .file("assets-foo", b"interleaved".to_vec())
+        .unwrap()
+        .external_resource("assets/logo.png")
+        .unwrap()
+        .build();
+    assert!(matches!(
+        built,
+        Err(PackBuildError::Invariant(
+            PackInvariantError::PathTreeConflict {
+                ref ancestor,
+                ref descendant,
+                ancestor_role: PackPathRole::ProjectFile,
+                descendant_role: PackPathRole::ExternalProjectResource,
+                package: None,
+            }
+        )) if ancestor == "assets" && descendant == "assets/logo.png"
+    ));
+
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\nexternal-resources = [\"assets/logo.png\"]\n";
+    let bytes = raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+        ("project/assets", b"packed"),
+        ("project/assets-foo", b"interleaved"),
+    ]);
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::Invariant(
+            PackInvariantError::PathTreeConflict {
+                ref ancestor,
+                ref descendant,
+                ancestor_role: PackPathRole::ProjectFile,
+                descendant_role: PackPathRole::ExternalProjectResource,
+                package: None,
+            }
+        )) if ancestor == "assets" && descendant == "assets/logo.png"
+    ));
+}
+
+#[test]
+fn pack_construction_rejects_conflicting_package_roles() {
+    use std::str::FromStr as _;
+
+    let spec = typst::syntax::package::PackageSpec::from_str("@local/example:1.0.0").unwrap();
+    let built = Pack::builder("main.typ")
+        .file("main.typ", Vec::new())
+        .unwrap()
+        .package_file(spec.clone(), "lib.typ", b"Hello".to_vec())
+        .unwrap()
+        .unvendored_package(spec)
+        .build();
+    assert!(matches!(
+        built,
+        Err(PackBuildError::Invariant(
+            PackInvariantError::PackageRoleConflict(ref spec)
+        )) if spec == "@local/example:1.0.0"
+    ));
+
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[packages]\nvendored = [\"@local/example:1.0.0\"]\nexternal = [\"@local/example:1.0.0\"]\n";
+    let bytes = raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+        ("packages/local/example/1.0.0/lib.typ", b"Hello"),
+    ]);
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::Invariant(
+            PackInvariantError::PackageRoleConflict(ref spec)
+        )) if spec == "@local/example:1.0.0"
+    ));
+}
+
+#[test]
+fn pack_construction_rejects_invalid_contained_font_data() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[[fonts]]\npath = \"custom-font.bin\"\nindex = 3\nfamilies = [\"Informational\"]\n";
+    let bytes = raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+        ("custom-font.bin", b"not a font"),
+    ]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::Invariant(PackInvariantError::InvalidFont {
+            path: Some(ref path),
+            index: 3,
+        })) if path == "custom-font.bin"
+    ));
+}
+
+#[test]
+fn pack_builder_reports_invalid_font_data_as_a_shared_invariant() {
+    assert!(matches!(
+        Pack::builder("main.typ").font(b"not a font".to_vec(), 2),
+        Err(PackBuildError::Invariant(PackInvariantError::InvalidFont {
+            path: None,
+            index: 2,
+        }))
+    ));
+}
+
+#[test]
+fn pack_construction_rejects_font_paths_reserved_for_project_files() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n[[fonts]]\npath = \"project/main.typ\"\nfamilies = [\"Informational\"]\n";
+    let bytes = raw_stored_zip(&[(MANIFEST_PATH, manifest), ("project/main.typ", b"Hello")]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::Invariant(PackInvariantError::ReservedFontPath {
+            ref path,
+            conflicting_role: PackPathRole::ProjectFile,
+        })) if path == "project/main.typ"
+    ));
+}
+
+#[test]
+fn a_constructed_pack_builds_a_world_without_revalidation() {
+    let pack = Pack::builder("main.typ")
+        .file("main.typ", Vec::new())
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let _: PackWorld = PackWorld::builder(pack).build();
+}
+
+#[test]
+fn pack_world_accepts_an_external_resource_reference() {
+    let pack = Pack::builder("main.typ")
+        .file("main.typ", Vec::new())
+        .unwrap()
+        .external_resource("resource.bin")
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let world = PackWorld::builder(pack)
+        .external_resource_reference(MemoryProjectFile::new("resource.bin", b"external".to_vec()))
+        .build();
+
+    assert_eq!(
+        world
+            .file(project_file_id("resource.bin"))
+            .unwrap()
+            .as_slice(),
+        b"external"
+    );
 }
 
 #[test]
@@ -284,11 +603,13 @@ fn pack_builder_rejects_external_project_resource_file_conflicts() {
 
     assert!(matches!(
         packed_first,
-        Err(PackBuildError::ExternalResourceConflict(path)) if path == "logo.png"
+        Err(PackBuildError::Invariant(PackInvariantError::PathRoleConflict { path, .. }))
+            if path == "logo.png"
     ));
     assert!(matches!(
         declared_first,
-        Err(PackBuildError::ExternalResourceConflict(path)) if path == "logo.png"
+        Err(PackBuildError::Invariant(PackInvariantError::PathRoleConflict { path, .. }))
+            if path == "logo.png"
     ));
 }
 
@@ -303,6 +624,158 @@ fn read_rejects_archives_without_manifest() {
     zip.finish().unwrap();
     let result = Pack::from_bytes(buffer.into_inner());
     assert!(matches!(result, Err(PackReadError::MissingManifest)));
+}
+
+#[test]
+fn read_reports_a_non_utf8_manifest_specifically() {
+    let bytes = raw_stored_zip(&[(MANIFEST_PATH, &[0xff]), ("project/main.typ", b"Hello")]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::ManifestNotUtf8(_))
+    ));
+}
+
+#[test]
+fn read_reports_a_non_file_manifest_specifically() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    let bytes = with_first_zip_entry_unix_mode(
+        raw_stored_zip(&[(MANIFEST_PATH, manifest), ("project/main.typ", b"Hello")]),
+        0o120777,
+    );
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::ManifestNotFile)
+    ));
+}
+
+#[test]
+fn read_rejects_unsafe_unknown_directories_before_ignoring_them() {
+    use std::io::Write as _;
+
+    let mut buffer = std::io::Cursor::new(Vec::new());
+    let mut zip = zip::ZipWriter::new(&mut buffer);
+    let options = zip::write::SimpleFileOptions::default();
+    zip.start_file(MANIFEST_PATH, options).unwrap();
+    zip.write_all(b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n")
+        .unwrap();
+    zip.start_file("project/main.typ", options).unwrap();
+    zip.write_all(b"Hello").unwrap();
+    zip.add_directory("../ignored/", options).unwrap();
+    zip.finish().unwrap();
+
+    assert!(matches!(
+        Pack::from_bytes(buffer.into_inner()),
+        Err(PackReadError::UnsafeEntry(_))
+    ));
+}
+
+#[test]
+fn read_rejects_a_windows_prefix_hidden_by_a_current_directory_alias() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    let bytes = raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+        ("./C:/ignored", b"must not be ignored"),
+    ]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::UnsafeEntry(_))
+    ));
+}
+
+#[test]
+fn read_rejects_duplicate_manifest_entries() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    let bytes = raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+    ]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::DuplicateManifest)
+    ));
+}
+
+#[test]
+fn read_rejects_distinct_archive_entries_with_one_canonical_identity() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    let bytes = raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"first"),
+        ("project/./main.typ", b"second"),
+    ]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::Invariant(
+            PackInvariantError::CanonicalArchiveEntryCollision {
+                ref canonical,
+                ..
+            }
+        )) if canonical == "project/main.typ"
+    ));
+}
+
+#[test]
+fn read_rejects_canonical_collisions_between_unknown_entries() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    let bytes = raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("project/main.typ", b"Hello"),
+        ("future/data", b"first"),
+        ("future/./data", b"second"),
+    ]);
+
+    assert!(matches!(
+        Pack::from_bytes(bytes),
+        Err(PackReadError::Invariant(
+            PackInvariantError::CanonicalArchiveEntryCollision {
+                ref canonical,
+                ..
+            }
+        )) if canonical == "future/data"
+    ));
+}
+
+#[test]
+fn read_does_not_normalize_a_known_role_into_an_ignored_archive_entry() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    for invalid in ["project/../ignored", "./project/../ignored"] {
+        let bytes = raw_stored_zip(&[
+            (MANIFEST_PATH, manifest),
+            ("project/main.typ", b"Hello"),
+            (invalid, b"must not be ignored"),
+        ]);
+
+        assert!(matches!(
+            Pack::from_bytes(bytes),
+            Err(PackReadError::Invariant(PackInvariantError::InvalidPath {
+                role: PackPathRole::ProjectFile,
+                ..
+            }))
+        ));
+    }
+}
+
+#[test]
+fn read_classifies_safe_archive_prefix_aliases_by_their_canonical_role() {
+    let manifest = b"format-version = 1\n[project]\nentrypoint = \"main.typ\"\n";
+    let pack = Pack::from_bytes(raw_stored_zip(&[
+        (MANIFEST_PATH, manifest),
+        ("./project/main.typ", b"Hello"),
+    ]))
+    .unwrap();
+
+    assert_eq!(pack.file("main.typ").unwrap().as_slice(), b"Hello");
+    assert_eq!(
+        pack.files().map(|(path, _)| path).collect::<Vec<_>>(),
+        ["main.typ"]
+    );
 }
 
 #[test]
@@ -326,7 +799,8 @@ fn read_rejects_external_project_resource_file_conflicts() {
     let result = Pack::from_bytes(buffer.into_inner());
     assert!(matches!(
         result,
-        Err(PackReadError::ExternalResourceConflict(path)) if path == "logo.png"
+        Err(PackReadError::Invariant(PackInvariantError::PathRoleConflict { path, .. }))
+            if path == "logo.png"
     ));
 }
 
@@ -346,7 +820,7 @@ fn parse_page_selection_understands_ranges() {
 
 #[cfg(feature = "cli")]
 #[test]
-fn cli_accepts_external_project_resource_options() {
+fn cli_accepts_source_references_without_a_resource_path_alias() {
     use clap::Parser as _;
 
     assert!(
@@ -354,9 +828,9 @@ fn cli_accepts_external_project_resource_options() {
             "typst-pack",
             "create",
             "project",
-            "--resource-path",
+            "--source-reference",
             "resources/first",
-            "--resource-path",
+            "--source-reference",
             "resources/second",
             "--external-resource",
             "assets/logo.png",
@@ -368,12 +842,22 @@ fn cli_accepts_external_project_resource_options() {
             "typst-pack",
             "compile",
             "project.typk",
-            "--resource-path",
+            "--source-reference",
             "resources/first",
-            "--resource-path",
+            "--source-reference",
             "resources/second",
         ])
         .is_ok()
+    );
+    assert!(
+        crate::cli::Cli::try_parse_from([
+            "typst-pack",
+            "compile",
+            "project.typk",
+            "--resource-path",
+            "resources/old",
+        ])
+        .is_err()
     );
 }
 
@@ -418,7 +902,7 @@ fn compile_in_memory_pack_to_pdf_and_svg() {
         .build()
         .unwrap();
 
-    let world = PackWorld::builder(pack).build().unwrap();
+    let world = PackWorld::builder(pack).build();
 
     let pdf = compile(&world, OutputFormat::Pdf, &CompileOptions::default()).unwrap();
     assert_eq!(pdf.artifacts.len(), 1);
@@ -441,7 +925,7 @@ fn compile_in_memory_pack_to_pdf_and_svg() {
 }
 
 #[test]
-fn declared_external_project_resource_compiles_through_loader() {
+fn declared_external_project_resource_compiles_through_a_reference() {
     let pack = Pack::builder("main.typ")
         .file(
             "main.typ",
@@ -455,9 +939,8 @@ fn declared_external_project_resource_compiles_through_loader() {
         .unwrap();
 
     let world = PackWorld::builder(pack.clone())
-        .external_resource_loader(MemoryProjectFile::new("assets/logo.png", tiny_png()))
-        .build()
-        .unwrap();
+        .external_resource_reference(MemoryProjectFile::new("assets/logo.png", tiny_png()))
+        .build();
     let pdf = compile(&world, OutputFormat::Pdf, &CompileOptions::default()).unwrap();
     assert!(pdf.artifacts[0].bytes().starts_with(b"%PDF"));
     let png = compile(&world, OutputFormat::Png, &CompileOptions::default()).unwrap();
@@ -474,10 +957,9 @@ fn declared_external_project_resource_compiles_through_loader() {
     );
 
     let world = PackWorld::builder(pack)
-        .external_resource_loader(MemoryProjectFile::new("assets/logo.png", tiny_png()))
+        .external_resource_reference(MemoryProjectFile::new("assets/logo.png", tiny_png()))
         .feature(typst::Feature::Html)
-        .build()
-        .unwrap();
+        .build();
     let html = compile(&world, OutputFormat::Html, &CompileOptions::default()).unwrap();
     assert!(
         std::str::from_utf8(html.artifacts[0].bytes())
@@ -487,7 +969,7 @@ fn declared_external_project_resource_compiles_through_loader() {
 }
 
 #[test]
-fn external_project_resource_loader_cannot_supply_typst_source() {
+fn external_resource_reference_cannot_supply_typst_source() {
     let pack = Pack::builder("main.typ")
         .file(
             "main.typ",
@@ -499,18 +981,17 @@ fn external_project_resource_loader_cannot_supply_typst_source() {
         .build()
         .unwrap();
     let world = PackWorld::builder(pack)
-        .external_resource_loader(MemoryProjectFile::new(
+        .external_resource_reference(MemoryProjectFile::new(
             "external.typ",
             b"#let mark = rect(width: 1pt, height: 1pt)".to_vec(),
         ))
-        .build()
-        .unwrap();
+        .build();
 
     assert!(compile(&world, OutputFormat::Svg, &CompileOptions::default()).is_err());
 }
 
 #[test]
-fn external_project_resource_loaders_follow_registration_order() {
+fn external_resource_references_follow_registration_order() {
     let pack = Pack::builder("main.typ")
         .file("main.typ", Vec::new())
         .unwrap()
@@ -523,10 +1004,9 @@ fn external_project_resource_loaders_follow_registration_order() {
     let (first, first_calls) = MemoryProjectFile::tracked("resource.bin", b"first".to_vec());
     let (second, second_calls) = MemoryProjectFile::tracked("resource.bin", b"second".to_vec());
     let world = PackWorld::builder(pack.clone())
-        .external_resource_loader(first)
-        .external_resource_loader(second)
-        .build()
-        .unwrap();
+        .external_resource_reference(first)
+        .external_resource_reference(second)
+        .build();
     assert_eq!(world.file(id).unwrap().as_slice(), b"first");
     assert_eq!(first_calls.load(Ordering::Relaxed), 1);
     assert_eq!(second_calls.load(Ordering::Relaxed), 0);
@@ -535,10 +1015,9 @@ fn external_project_resource_loaders_follow_registration_order() {
     let (fallback, fallback_calls) =
         MemoryProjectFile::tracked("resource.bin", b"fallback".to_vec());
     let world = PackWorld::builder(pack.clone())
-        .external_resource_loader(missing)
-        .external_resource_loader(fallback)
-        .build()
-        .unwrap();
+        .external_resource_reference(missing)
+        .external_resource_reference(fallback)
+        .build();
     assert_eq!(world.file(id).unwrap().as_slice(), b"fallback");
     assert_eq!(missing_calls.load(Ordering::Relaxed), 1);
     assert_eq!(fallback_calls.load(Ordering::Relaxed), 1);
@@ -546,17 +1025,62 @@ fn external_project_resource_loaders_follow_registration_order() {
     let (denied, denied_calls) = ErrorProjectLoader::tracked(FileError::AccessDenied);
     let (masked, masked_calls) = MemoryProjectFile::tracked("resource.bin", b"masked".to_vec());
     let world = PackWorld::builder(pack)
-        .external_resource_loader(denied)
-        .external_resource_loader(masked)
-        .build()
-        .unwrap();
+        .external_resource_reference(denied)
+        .external_resource_reference(masked)
+        .build();
     assert_eq!(world.file(id), Err(FileError::AccessDenied));
     assert_eq!(denied_calls.load(Ordering::Relaxed), 1);
     assert_eq!(masked_calls.load(Ordering::Relaxed), 0);
 }
 
 #[test]
-fn packed_and_undeclared_project_paths_do_not_consult_external_loaders() {
+fn all_missing_external_resource_references_report_the_requested_project_path_lazily() {
+    let pack = Pack::builder("main.typ")
+        .file("main.typ", Vec::new())
+        .unwrap()
+        .external_resource("requested.bin")
+        .unwrap()
+        .external_resource("unused.bin")
+        .unwrap()
+        .build()
+        .unwrap();
+    let (reference, calls) = ErrorProjectLoader::tracked(FileError::NotFound(PathBuf::from(
+        "/host-specific/missing.bin",
+    )));
+    let world = PackWorld::builder(pack)
+        .external_resource_reference(reference)
+        .build();
+
+    assert_eq!(
+        world.file(project_file_id("requested.bin")),
+        Err(FileError::NotFound(PathBuf::from("requested.bin")))
+    );
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn source_requests_do_not_consult_external_resource_references() {
+    let pack = Pack::builder("main.typ")
+        .file("main.typ", Vec::new())
+        .unwrap()
+        .external_resource("external.typ")
+        .unwrap()
+        .build()
+        .unwrap();
+    let (reference, calls) = MemoryProjectFile::tracked("external.typ", b"injected".to_vec());
+    let world = PackWorld::builder(pack)
+        .external_resource_reference(reference)
+        .build();
+
+    assert!(matches!(
+        world.source(project_file_id("external.typ")),
+        Err(FileError::NotFound(_))
+    ));
+    assert_eq!(calls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn packed_and_undeclared_project_paths_do_not_consult_external_resource_references() {
     let packed = Pack::builder("main.typ")
         .file("main.typ", Vec::new())
         .unwrap()
@@ -566,9 +1090,8 @@ fn packed_and_undeclared_project_paths_do_not_consult_external_loaders() {
         .unwrap();
     let (loader, calls) = MemoryProjectFile::tracked("resource.bin", b"external".to_vec());
     let world = PackWorld::builder(packed)
-        .external_resource_loader(loader)
-        .build()
-        .unwrap();
+        .external_resource_reference(loader)
+        .build();
     assert_eq!(
         world
             .file(project_file_id("resource.bin"))
@@ -585,9 +1108,8 @@ fn packed_and_undeclared_project_paths_do_not_consult_external_loaders() {
         .unwrap();
     let (loader, calls) = MemoryProjectFile::tracked("missing.bin", b"external".to_vec());
     let world = PackWorld::builder(undeclared)
-        .external_resource_loader(loader)
-        .build()
-        .unwrap();
+        .external_resource_reference(loader)
+        .build();
     assert!(matches!(
         world.file(project_file_id("missing.bin")),
         Err(FileError::NotFound(_))
@@ -596,7 +1118,7 @@ fn packed_and_undeclared_project_paths_do_not_consult_external_loaders() {
 }
 
 #[test]
-fn package_requests_do_not_consult_external_project_resource_loaders() {
+fn package_requests_do_not_consult_external_resource_references() {
     use std::str::FromStr as _;
 
     let pack = Pack::builder("main.typ")
@@ -608,9 +1130,8 @@ fn package_requests_do_not_consult_external_project_resource_loaders() {
         .unwrap();
     let (loader, calls) = MemoryProjectFile::tracked("lib.typ", b"external".to_vec());
     let world = PackWorld::builder(pack)
-        .external_resource_loader(loader)
-        .build()
-        .unwrap();
+        .external_resource_reference(loader)
+        .build();
     let spec = typst::syntax::package::PackageSpec::from_str("@local/example:1.0.0").unwrap();
     let id = RootedPath::new(
         VirtualRoot::Package(spec),
@@ -630,10 +1151,7 @@ fn project_requests_do_not_consult_package_loader() {
         .build()
         .unwrap();
     let (loader, calls) = MemoryProjectFile::tracked("missing.txt", b"host file".to_vec());
-    let world = PackWorld::builder(pack)
-        .package_loader(loader)
-        .build()
-        .unwrap();
+    let world = PackWorld::builder(pack).package_loader(loader).build();
 
     assert!(compile(&world, OutputFormat::Svg, &CompileOptions::default()).is_err());
     assert_eq!(calls.load(Ordering::Relaxed), 0);
@@ -666,10 +1184,7 @@ fn vendored_package_compiles_without_consulting_package_loader() {
         .build()
         .unwrap();
     let (loader, calls) = MemoryProjectFile::tracked("unused", Vec::new());
-    let world = PackWorld::builder(pack)
-        .package_loader(loader)
-        .build()
-        .unwrap();
+    let world = PackWorld::builder(pack).package_loader(loader).build();
 
     assert!(compile(&world, OutputFormat::Svg, &CompileOptions::default()).is_ok());
     assert_eq!(calls.load(Ordering::Relaxed), 0);
@@ -699,10 +1214,7 @@ fn missing_vendored_package_file_does_not_fall_through_to_package_loader() {
         "missing.typ",
         b"#let mark = rect(width: 1pt, height: 1pt)".to_vec(),
     );
-    let world = PackWorld::builder(pack)
-        .package_loader(loader)
-        .build()
-        .unwrap();
+    let world = PackWorld::builder(pack).package_loader(loader).build();
 
     assert!(compile(&world, OutputFormat::Svg, &CompileOptions::default()).is_err());
     assert_eq!(calls.load(Ordering::Relaxed), 0);
@@ -910,7 +1422,7 @@ Rows: #csv("data.csv").len()
         let outcome = Packer::new(&project, "main.typ")
             .system_fonts(false)
             .project_resource_policy(ProjectResourcePolicy::AllowExternalFallback)
-            .external_resource_loader(MemoryProjectFile::new("assets/logo.png", tiny_png()))
+            .external_resource_reference(MemoryProjectFile::new("assets/logo.png", tiny_png()))
             .pack()
             .unwrap();
 
@@ -923,7 +1435,7 @@ Rows: #csv("data.csv").len()
             pack.external_resources().collect::<Vec<_>>(),
             ["assets/logo.png"]
         );
-        let world = PackWorld::builder(pack.clone()).build().unwrap();
+        let world = PackWorld::builder(pack.clone()).build();
         match compile(&world, OutputFormat::Svg, &CompileOptions::default()) {
             Err(CompileError::Diagnostics { errors, .. }) => assert!(
                 errors
@@ -934,9 +1446,8 @@ Rows: #csv("data.csv").len()
         }
 
         let world = PackWorld::builder(pack)
-            .external_resource_loader(MemoryProjectFile::new("assets/logo.png", tiny_png()))
-            .build()
-            .unwrap();
+            .external_resource_reference(MemoryProjectFile::new("assets/logo.png", tiny_png()))
+            .build();
         let output = compile(&world, OutputFormat::Svg, &CompileOptions::default()).unwrap();
         assert!(
             std::str::from_utf8(output.artifacts[0].bytes())
@@ -971,7 +1482,7 @@ Rows: #csv("data.csv").len()
         );
 
         let pack = Pack::from_bytes(outcome.pack.to_bytes().unwrap()).unwrap();
-        let world = PackWorld::builder(pack.clone()).build().unwrap();
+        let world = PackWorld::builder(pack.clone()).build();
         match compile(&world, OutputFormat::Svg, &CompileOptions::default()) {
             Err(CompileError::Diagnostics { errors, .. }) => assert!(
                 errors
@@ -981,9 +1492,8 @@ Rows: #csv("data.csv").len()
             _ => panic!("missing External Project Resource did not produce a file diagnostic"),
         }
         let world = PackWorld::builder(pack.clone())
-            .external_resource_loader(MemoryProjectFile::new("assets/logo.png", tiny_png()))
-            .build()
-            .unwrap();
+            .external_resource_reference(MemoryProjectFile::new("assets/logo.png", tiny_png()))
+            .build();
         assert!(compile(&world, OutputFormat::Svg, &CompileOptions::default()).is_ok());
 
         let target = dir.path().join("extracted");
@@ -1032,8 +1542,72 @@ Rows: #csv("data.csv").len()
 
         assert!(matches!(
             result,
-            Err(PackerError::Build(PackBuildError::ExternalResourceConflict(path)))
-                if path == "conditional.txt"
+            Err(PackerError::Build(PackBuildError::Invariant(
+                PackInvariantError::PathRoleConflict { path, .. }
+            ))) if path == "conditional.txt"
+        ));
+    }
+
+    #[test]
+    fn external_entrypoint_declaration_fails_before_discovery() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        fs::write(project.join("main.typ"), "Hello").unwrap();
+
+        let result = Packer::new(&project, "main.typ")
+            .system_fonts(false)
+            .external_resource("main.typ")
+            .pack();
+
+        assert!(matches!(
+            result,
+            Err(PackerError::Build(PackBuildError::Invariant(
+                PackInvariantError::EntrypointIsExternalResource(ref path)
+            ))) if path == "main.typ"
+        ));
+    }
+
+    #[test]
+    fn external_resource_tree_conflicts_fail_before_discovery() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        fs::write(project.join("main.typ"), "#panic(\"discovery ran\")").unwrap();
+
+        let result = Packer::new(&project, "main.typ")
+            .system_fonts(false)
+            .external_resource("assets")
+            .external_resource("assets/logo.png")
+            .pack();
+
+        assert!(matches!(
+            result,
+            Err(PackerError::Build(PackBuildError::Invariant(
+                PackInvariantError::PathTreeConflict {
+                    ancestor_role: PackPathRole::ExternalProjectResource,
+                    descendant_role: PackPathRole::ExternalProjectResource,
+                    package: None,
+                    ..
+                }
+            )))
+        ));
+
+        let result = Packer::new(&project, "main.typ")
+            .system_fonts(false)
+            .external_resource("main.typ/child")
+            .pack();
+
+        assert!(matches!(
+            result,
+            Err(PackerError::Build(PackBuildError::Invariant(
+                PackInvariantError::PathTreeConflict {
+                    ancestor_role: PackPathRole::Entrypoint,
+                    descendant_role: PackPathRole::ExternalProjectResource,
+                    package: None,
+                    ..
+                }
+            )))
         ));
     }
 
@@ -1052,7 +1626,7 @@ Rows: #csv("data.csv").len()
             MemoryProjectFile::tracked("assets/logo.png", tiny_png());
         let strict = Packer::new(&project, "main.typ")
             .system_fonts(false)
-            .external_resource_loader(strict_loader)
+            .external_resource_reference(strict_loader)
             .pack();
         assert!(matches!(strict, Err(PackerError::Compile { .. })));
         assert_eq!(strict_calls.load(Ordering::Relaxed), 0);
@@ -1063,12 +1637,72 @@ Rows: #csv("data.csv").len()
         let outcome = Packer::new(&project, "main.typ")
             .system_fonts(false)
             .project_resource_policy(ProjectResourcePolicy::AllowExternalFallback)
-            .external_resource_loader(fallback)
+            .external_resource_reference(fallback)
             .pack()
             .unwrap();
         assert!(outcome.pack.file("assets/logo.png").is_some());
         assert!(outcome.report.external_resources.is_empty());
         assert_eq!(fallback_calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn discovery_uses_external_resource_references_in_registration_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        fs::write(project.join("main.typ"), "#read(\"resource.bin\")").unwrap();
+
+        let (missing, missing_calls) = MemoryProjectFile::tracked("other.bin", Vec::new());
+        let (fallback, fallback_calls) =
+            MemoryProjectFile::tracked("resource.bin", b"fallback".to_vec());
+        let outcome = Packer::new(&project, "main.typ")
+            .system_fonts(false)
+            .project_resource_policy(ProjectResourcePolicy::AllowExternalFallback)
+            .external_resource_reference(missing)
+            .external_resource_reference(fallback)
+            .pack()
+            .unwrap();
+
+        assert_eq!(missing_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(fallback_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(outcome.report.external_resources, ["resource.bin"]);
+        assert!(outcome.pack.file("resource.bin").is_none());
+    }
+
+    #[test]
+    fn strict_discovery_does_not_resolve_an_explicit_missing_resource() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        fs::write(project.join("main.typ"), "#read(\"resource.bin\")").unwrap();
+
+        let (reference, calls) = MemoryProjectFile::tracked("resource.bin", b"external".to_vec());
+        let result = Packer::new(&project, "main.typ")
+            .system_fonts(false)
+            .external_resource("resource.bin")
+            .external_resource_reference(reference)
+            .pack();
+
+        assert!(matches!(result, Err(PackerError::Compile { .. })));
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn discovery_does_not_mask_a_non_missing_primary_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        fs::create_dir_all(project.join("resource.bin")).unwrap();
+        fs::write(project.join("main.typ"), "#read(\"resource.bin\")").unwrap();
+
+        let (reference, calls) = MemoryProjectFile::tracked("resource.bin", b"external".to_vec());
+        let result = Packer::new(&project, "main.typ")
+            .system_fonts(false)
+            .project_resource_policy(ProjectResourcePolicy::AllowExternalFallback)
+            .external_resource_reference(reference)
+            .pack();
+
+        assert!(matches!(result, Err(PackerError::Compile { .. })));
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
     }
 
     #[cfg(unix)]
@@ -1114,7 +1748,7 @@ Rows: #csv("data.csv").len()
         let outcome = Packer::new(&project, "main.typ")
             .system_fonts(false)
             .project_resource_policy(ProjectResourcePolicy::AllowExternalFallback)
-            .external_resource_loader(loader)
+            .external_resource_reference(loader)
             .pack()
             .unwrap();
         writer.join().unwrap();
@@ -1136,7 +1770,7 @@ Rows: #csv("data.csv").len()
         let mut outcome = Packer::new(&project, "main.typ")
             .system_fonts(false)
             .project_resource_policy(ProjectResourcePolicy::AllowExternalFallback)
-            .external_resource_loader(BlockingProjectFile {
+            .external_resource_reference(BlockingProjectFile {
                 path: "external.typ".to_owned(),
                 data: Bytes::new(b"#let injected = true".to_vec()),
                 entered: Arc::clone(&raw_entered),
@@ -1175,6 +1809,45 @@ Rows: #csv("data.csv").len()
         });
     }
 
+    #[test]
+    fn concurrent_successful_discovery_fallback_records_one_provenance_entry() {
+        let entered = Arc::new(std::sync::Barrier::new(3));
+        let release = Arc::new(std::sync::Barrier::new(3));
+        let discovery = crate::external_resource::Discovery::new(
+            vec![Box::new(BlockingProjectFile {
+                path: "shared.bin".to_owned(),
+                data: Bytes::new(b"external".to_vec()),
+                entered: Arc::clone(&entered),
+                release: Arc::clone(&release),
+            })],
+            true,
+            std::collections::BTreeSet::new(),
+        );
+        let id = project_file_id("shared.bin");
+
+        std::thread::scope(|scope| {
+            let first = scope.spawn(|| {
+                discovery.file(id, || Err(FileError::NotFound(PathBuf::from("shared.bin"))))
+            });
+            let second = scope.spawn(|| {
+                discovery.file(id, || Err(FileError::NotFound(PathBuf::from("shared.bin"))))
+            });
+            entered.wait();
+            release.wait();
+
+            assert_eq!(
+                first.join().unwrap().unwrap(),
+                Bytes::new(b"external".to_vec())
+            );
+            assert_eq!(
+                second.join().unwrap().unwrap(),
+                Bytes::new(b"external".to_vec())
+            );
+        });
+
+        assert_eq!(discovery.external_resources(), vec!["shared.bin"]);
+    }
+
     #[cfg(feature = "embedded-fonts")]
     #[test]
     fn packed_project_compiles_offline() {
@@ -1183,7 +1856,7 @@ Rows: #csv("data.csv").len()
 
         // Round-trip through bytes: nothing may depend on the file system.
         let pack = Pack::from_bytes(outcome.pack.to_bytes().unwrap()).unwrap();
-        let world = PackWorld::builder(pack).build().unwrap();
+        let world = PackWorld::builder(pack).build();
         let output = compile(&world, OutputFormat::Pdf, &CompileOptions::default()).unwrap();
         assert!(output.artifacts[0].bytes().starts_with(b"%PDF"));
     }
@@ -1205,7 +1878,7 @@ Rows: #csv("data.csv").len()
         let pack = Pack::from_bytes(outcome.pack.to_bytes().unwrap()).unwrap();
 
         // Without a loader, compilation must fail...
-        let world = PackWorld::builder(pack.clone()).build().unwrap();
+        let world = PackWorld::builder(pack.clone()).build();
         let error = compile(&world, OutputFormat::Pdf, &CompileOptions::default()).unwrap_err();
         let CompileError::Diagnostics { errors, .. } = error else {
             panic!("unvendored package did not produce a compilation diagnostic");
@@ -1228,10 +1901,7 @@ Rows: #csv("data.csv").len()
             None,
             UniversePackages::new(SystemDownloader::new("typst-pack-test")),
         ));
-        let world = PackWorld::builder(pack)
-            .package_loader(loader)
-            .build()
-            .unwrap();
+        let world = PackWorld::builder(pack).package_loader(loader).build();
         let output = compile(&world, OutputFormat::Pdf, &CompileOptions::default()).unwrap();
         assert!(output.artifacts[0].bytes().starts_with(b"%PDF"));
     }
@@ -1263,7 +1933,7 @@ Rows: #csv("data.csv").len()
         assert!(!full.pack.fonts().is_empty());
         // The embedded fonts must load again from the pack.
         let pack = Pack::from_bytes(full.pack.to_bytes().unwrap()).unwrap();
-        PackWorld::builder(pack).build().unwrap();
+        PackWorld::builder(pack).build();
     }
 
     #[test]
@@ -1314,14 +1984,13 @@ fn html_output_is_gated_by_the_html_feature() {
         .unwrap();
 
     // Without the feature, Typst itself rejects HTML export.
-    let world = PackWorld::builder(pack.clone()).build().unwrap();
+    let world = PackWorld::builder(pack.clone()).build();
     assert!(compile(&world, OutputFormat::Html, &CompileOptions::default()).is_err());
 
     // With the feature, it produces a document plus an "experimental" warning.
     let world = PackWorld::builder(pack)
         .feature(typst::Feature::Html)
-        .build()
-        .unwrap();
+        .build();
     let output = compile(&world, OutputFormat::Html, &CompileOptions::default()).unwrap();
     let html = std::str::from_utf8(output.artifacts[0].bytes()).unwrap();
     assert!(html.contains("<html"));

--- a/src/world.rs
+++ b/src/world.rs
@@ -13,6 +13,7 @@ use typst::{Feature, Library, LibraryExt, World};
 use typst_kit::files::{FileLoader, FileStore};
 use typst_kit::fonts::{FontSource, FontStore};
 
+use crate::external_resource::{Compilation as ExternalResources, Reference};
 use crate::pack::Pack;
 
 #[cfg(feature = "fs")]
@@ -49,9 +50,9 @@ pub(crate) fn system_packages(
 /// Project files and vendored package files come from the pack. Fonts come
 /// from the pack, plus any fonts configured on the builder. Files of packages
 /// that are not vendored are only available if a package loader is configured.
-/// Declared External Project Resources may come from external resource loaders;
-/// these loaders cannot replace packed files or supply Typst source or package
-/// files.
+/// Declared External Project Resources may come from External Resource
+/// References; these references cannot replace packed files or supply Typst
+/// source or package files.
 pub struct PackWorld {
     library: LazyHash<Library>,
     main: FileId,
@@ -67,7 +68,7 @@ impl PackWorld {
     }
 
     /// Creates a world with default configuration.
-    pub fn new(pack: Pack) -> Result<Self, PackWorldError> {
+    pub fn new(pack: Pack) -> Self {
         Self::builder(pack).build()
     }
 
@@ -91,19 +92,10 @@ impl World for PackWorld {
     }
 
     fn source(&self, id: FileId) -> FileResult<Source> {
-        if matches!(id.root(), VirtualRoot::Project)
-            && self
-                .store
-                .loader()
-                .pack
-                .file(id.vpath().get_without_slash())
-                .is_none()
-        {
-            return Err(FileError::NotFound(PathBuf::from(
-                id.vpath().get_without_slash(),
-            )));
-        }
-        self.store.source(id)
+        let loader = self.store.loader();
+        loader
+            .external_resources
+            .source(&loader.pack, id, || self.store.source(id))
     }
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {
@@ -141,38 +133,18 @@ enum Clock {
 /// that are not vendored.
 struct PackLoader {
     pack: Arc<Pack>,
-    external_resource_loaders: Vec<Box<dyn FileLoader + Send + Sync>>,
+    external_resources: ExternalResources,
     package_loader: Option<Box<dyn FileLoader + Send + Sync>>,
-}
-
-pub(crate) fn load_external_resource(
-    loaders: &[Box<dyn FileLoader + Send + Sync>],
-    id: FileId,
-) -> FileResult<Bytes> {
-    for loader in loaders {
-        match loader.load(id) {
-            Err(FileError::NotFound(_)) => {}
-            result => return result,
-        }
-    }
-    Err(FileError::NotFound(PathBuf::from(
-        id.vpath().get_without_slash(),
-    )))
 }
 
 impl FileLoader for PackLoader {
     fn load(&self, id: FileId) -> FileResult<Bytes> {
         let path = id.vpath().get_without_slash();
         match id.root() {
-            VirtualRoot::Project => {
-                if let Some(data) = self.pack.file(path) {
-                    return Ok(data.clone());
-                }
-                if !self.pack.is_external_resource(path) {
-                    return Err(FileError::NotFound(PathBuf::from(path)));
-                }
-                load_external_resource(&self.external_resource_loaders, id)
-            }
+            VirtualRoot::Project => self
+                .external_resources
+                .file(&self.pack, id)
+                .expect("project requests are handled by External Project Resource resolution"),
             VirtualRoot::Package(spec) => {
                 if self.pack.has_package(spec) {
                     self.pack
@@ -204,7 +176,7 @@ pub struct PackWorldBuilder {
     #[cfg_attr(not(feature = "embedded-fonts"), allow(dead_code))]
     embedded_fonts: bool,
     extra_fonts: Vec<(BoxedFontSource, FontInfo)>,
-    external_resource_loaders: Vec<Box<dyn FileLoader + Send + Sync>>,
+    external_resource_references: Vec<Reference>,
     package_loader: Option<Box<dyn FileLoader + Send + Sync>>,
 }
 
@@ -226,7 +198,7 @@ impl PackWorldBuilder {
             clock: Clock::None,
             embedded_fonts: cfg!(feature = "embedded-fonts"),
             extra_fonts: Vec::new(),
-            external_resource_loaders: Vec::new(),
+            external_resource_references: Vec::new(),
             package_loader: None,
         }
     }
@@ -292,30 +264,26 @@ impl PackWorldBuilder {
         self
     }
 
-    /// Adds a loader for declared External Project Resources.
+    /// Adds an External Resource Reference for declared External Project Resources.
     ///
-    /// Loaders are tried in registration order after packed project files.
-    pub fn external_resource_loader(
+    /// References are tried in registration order after packed project files.
+    pub fn external_resource_reference(
         mut self,
-        loader: impl FileLoader + Send + Sync + 'static,
+        reference: impl FileLoader + Send + Sync + 'static,
     ) -> Self {
-        self.external_resource_loaders.push(Box::new(loader));
+        self.external_resource_references.push(Box::new(reference));
         self
     }
 
     /// Builds the world.
-    pub fn build(self) -> Result<PackWorld, PackWorldError> {
-        let entrypoint = self
-            .pack
-            .manifest()
-            .entrypoint()
-            .map_err(|err| PackWorldError::InvalidPack(err.to_string()))?;
+    pub fn build(self) -> PackWorld {
+        let entrypoint = typst::syntax::VirtualPath::new(self.pack.entrypoint())
+            .expect("Pack entrypoint invariant violated");
         let main = RootedPath::new(VirtualRoot::Project, entrypoint).intern();
 
         let mut fonts = FontStore::new();
         for pack_font in self.pack.fonts() {
-            let font = Font::new(pack_font.data.clone(), pack_font.entry.index)
-                .ok_or_else(|| PackWorldError::InvalidFont(pack_font.entry.path.clone()))?;
+            let font = pack_font.font().clone();
             let info = font.info().clone();
             fonts.push((font, info));
         }
@@ -330,17 +298,17 @@ impl PackWorldBuilder {
             .with_features(self.features.into_iter().collect())
             .build();
 
-        Ok(PackWorld {
+        PackWorld {
             library: LazyHash::new(library),
             main,
             store: FileStore::new(PackLoader {
                 pack: Arc::new(self.pack),
-                external_resource_loaders: self.external_resource_loaders,
+                external_resources: ExternalResources::new(self.external_resource_references),
                 package_loader: self.package_loader,
             }),
             fonts,
             clock: self.clock,
-        })
+        }
     }
 }
 
@@ -399,13 +367,4 @@ impl FileLoader for SystemPackageLoader {
             VirtualRoot::Package(spec) => Ok(self.0.obtain(spec)?.load(id.vpath())?),
         }
     }
-}
-
-/// A failure while building a [`PackWorld`].
-#[derive(Debug, thiserror::Error)]
-pub enum PackWorldError {
-    #[error("pack is not usable: {0}")]
-    InvalidPack(String),
-    #[error("embedded font `{0}` could not be loaded")]
-    InvalidFont(String),
 }

--- a/tests/compilation.rs
+++ b/tests/compilation.rs
@@ -15,7 +15,7 @@ fn five_page_world() -> PackWorld {
         .build()
         .unwrap();
 
-    PackWorld::builder(pack).build().unwrap()
+    PackWorld::builder(pack).build()
 }
 
 #[test]
@@ -29,7 +29,7 @@ fn pdf_is_one_document_format_artifact() {
         .unwrap()
         .build()
         .unwrap();
-    let world = PackWorld::builder(pack).build().unwrap();
+    let world = PackWorld::builder(pack).build();
 
     let output = compile(&world, OutputFormat::Pdf, &CompileOptions::default()).unwrap();
 
@@ -52,7 +52,7 @@ fn page_format_selection_matching_no_source_page_fails() {
         .unwrap()
         .build()
         .unwrap();
-    let world = PackWorld::builder(pack).build().unwrap();
+    let world = PackWorld::builder(pack).build();
     for expression in ["2-1", "9", "9-"] {
         let options = CompileOptions {
             page_selection: typst_pack::parse_page_selection(expression).unwrap(),
@@ -238,8 +238,7 @@ fn html_is_one_document_format_artifact() {
         .unwrap();
     let world = PackWorld::builder(pack)
         .feature(typst::Feature::Html)
-        .build()
-        .unwrap();
+        .build();
 
     let output = compile(&world, OutputFormat::Html, &CompileOptions::default()).unwrap();
 
@@ -265,7 +264,7 @@ fn no_matching_source_pages_error_retains_compilation_warnings() {
         .unwrap()
         .build()
         .unwrap();
-    let world = PackWorld::builder(pack).build().unwrap();
+    let world = PackWorld::builder(pack).build();
     let options = CompileOptions {
         page_selection: typst_pack::parse_page_selection("9").unwrap(),
         ..CompileOptions::default()


### PR DESCRIPTION
Fixes #15
Fixes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added external resource references for pack creation and compilation.
  * Added repeated `--source-reference` CLI support with ordered fallback resolution.
  * Improved pack handling with canonical paths, centralized resource resolution, and stronger archive validation.

* **Breaking Changes**
  * Replaced resource-path and external resource loader terminology and APIs with source references.
  * Pack world construction now returns directly without error wrapping.
  * Updated manifest access and resource slot/provider terminology.

* **Documentation**
  * Added architecture decision records covering pack invariants, resource resolution, and CLI alignment.
  * Updated README migration guidance and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->